### PR TITLE
DDCE-75: Fixed caching permissions issue

### DIFF
--- a/app/utils/CacheUtil.scala
+++ b/app/utils/CacheUtil.scala
@@ -107,6 +107,7 @@ trait CacheUtil {
       res.get.as[T]
     }recover{
       case e: NoSuchElementException => {
+				Logger.error(s"[CacheUtil][fetch] Nothing found in the cache for $key - $e")
         throw new NoSuchElementException
       }
       case _ : Throwable => {
@@ -124,7 +125,8 @@ trait CacheUtil {
       res.get.as[T]
     } recover {
       case e: NoSuchElementException => {
-        throw new NoSuchElementException
+				Logger.error(s"[CacheUtil][fetch] Nothing found in the cache for $key - $e")
+				throw new NoSuchElementException
       }
       case er : Throwable => {
         Logger.error(s"fetch with 2 params failed to get key $key for $cacheId with exception ${er.getMessage}, timestamp: ${System.currentTimeMillis()}.")
@@ -140,7 +142,7 @@ trait CacheUtil {
       res
     } recover {
       case e: NoSuchElementException => {
-        throw new NoSuchElementException
+				throw new NoSuchElementException
       }
       case _: Throwable => {
         Logger.error(s"fetchOption with 2 params failed to get key $key for $cacheId with exception, timestamp: ${System.currentTimeMillis()}.")
@@ -148,7 +150,7 @@ trait CacheUtil {
       }
     }
   }
-  
+
 
 
   @throws(classOf[NoSuchElementException])
@@ -167,7 +169,7 @@ trait CacheUtil {
       }
     }
   }
-  
+
   def getAltAmmendsData(schemeRef: String)(implicit hc: HeaderCarrier, ec: ExecutionContext, request: Request[AnyRef]): Future[(Option[AltAmendsActivity], Option[AlterationAmends])] = {
     fetchOption[AltAmendsActivity](CacheUtil.altAmendsActivity, schemeRef).flatMap {
       altamends =>

--- a/test/controllers/ReturnServiceControllerTest.scala
+++ b/test/controllers/ReturnServiceControllerTest.scala
@@ -128,7 +128,7 @@ class ReturnServiceControllerTest extends UnitSpec with ERSFakeApplicationConfig
       val controllerUnderTest = buildFakeReturnServiceController()
       controllerUnderTest.fetchMapVal = "withMatchingSchemeRef"
 
-      val result = controllerUnderTest.cacheParams(ersRequestObject)(Fixtures.buildFakeUser, Fixtures.buildFakeRequestWithSessionIdCSOP("GET"), hc)
+      val result = controllerUnderTest.cacheParams(ersRequestObject)(Fixtures.buildFakeRequestWithSessionIdCSOP("GET"), hc)
       status(result) shouldBe Status.OK
       val document = Jsoup.parse(contentAsString(result))
       document.getElementsByTag("h1").text() should include(Messages("ers_start.page_title", ersRequestObject.getSchemeName))
@@ -140,7 +140,7 @@ class ReturnServiceControllerTest extends UnitSpec with ERSFakeApplicationConfig
       val controllerUnderTest = buildFakeReturnServiceController()
       controllerUnderTest.fetchMapVal = "withNonMatchingSchemeRef"
 
-      val result = controllerUnderTest.cacheParams(ersRequestObject)(Fixtures.buildFakeUser, Fixtures.buildFakeRequestWithSessionIdCSOP("GET"), hc)
+      val result = controllerUnderTest.cacheParams(ersRequestObject)(Fixtures.buildFakeRequestWithSessionIdCSOP("GET"), hc)
       status(result) shouldBe Status.OK
     }
   }

--- a/test/utils/CacheUtilSpec.scala
+++ b/test/utils/CacheUtilSpec.scala
@@ -100,16 +100,14 @@ class CacheUtilSpec extends UnitSpec with MockitoSugar with BeforeAndAfterEach w
       result shouldBe altAmends
     }
 
-    "throw NoSuchElementException if value is not found in cache" in {
-      when(
-        mockShortLivedCache.fetchAndGetEntry[JsValue](anyString(), anyString())(any(), any(), any())
-      ).thenReturn(
-        Future.failed(new NoSuchElementException)
-      )
-      intercept[NoSuchElementException] {
-        await(cacheUtil.fetch[AltAmends]("key"))
-      }
-    }
+		"throw NoSuchElementException if value is not found in cache" in {
+			when(mockShortLivedCache.fetchAndGetEntry[JsValue](anyString(), anyString())(any(), any(), any()))
+				.thenReturn(Future.successful(None))
+
+			intercept[NoSuchElementException] {
+				await(cacheUtil.fetch[AltAmends]("key"))
+			}
+		}
 
     "throw Exception if an exception occurs" in {
       when(


### PR DESCRIPTION
Issue was that if a user was an agent, they were attempted to retrieve a requestObject that wasn't cached yet. For the introductory page, it will now check the user is authorised for that page, cache, then retrieve from the following page onwards.