### PR TITLE
removed CSRF bypass because no allowlist header present

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -28,12 +28,6 @@ play {
   modules.enabled+="com.kenshoo.play.metrics.PlayModule"
   filters {
     csrf {
-      header {
-        bypassHeaders {
-          X-Requested-With = "*"
-          Csrf-Token = "nocheck"
-        }
-      }
       contentType.blackList = ["application/x-www-form-urlencoded", "multipart/form-data", "text/plain"]
     }
     headers.contentSecurityPolicy= "default-src 'self' 'unsafe-inline' localhost:9032 localhost:9250 assets.digital.cabinet-office.gov.uk www.google-analytics.com data:"


### PR DESCRIPTION
A large number of configuration files in production contains code which allows the anti-csrf checks to be bypassed:

The CSRF bypass header is being used without an allowlist. Have removed it in this commit to close this vulnerability.
https://jira.tools.tax.service.gov.uk/browse/PSEC-1051