### PR TITLE
[EH] Updated government gateway link for test envs

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -111,7 +111,7 @@ auditing {
 }
 
 government-gateway-sign-in {
-  host = "http://localhost:9949/gg/sign-in"
+  host = "http://localhost:9949/auth-login-stub/gg-sign-in"
 }
 
 microservice {


### PR DESCRIPTION
# Bug fix

Change the government gateway redirect url to the correct place for local/dev/staging. 

