### PR TITLE
[DP][DDCE-1518] Migrate to tracking consent frontend

### DIFF
--- a/app/config/ApplicationConfig.scala
+++ b/app/config/ApplicationConfig.scala
@@ -44,11 +44,8 @@ class ApplicationConfig @Inject()(config: ServicesConfig) {
 
 	lazy val reportAProblemPartialUrl: String = s"$contactHost/contact/problem_reports_ajax?service=$contactFormServiceIdentifier"
 	lazy val reportAProblemNonJSUrl: String = s"$contactHost/contact/problem_reports_nonjs?service=$contactFormServiceIdentifier"
-	lazy val gaToken: String = config.getString(s"govuk-tax.google-analytics.token")
 
 	lazy val assetsPrefix: String = config.getString("assets.url") + config.getString("assets.version")
-	lazy val analyticsToken: String = config.getString("govuk-tax.google-analytics.token")
-	lazy val analyticsHost: String = config.getString("govuk-tax.google-analytics.host")
 	lazy val ersUrl: String = config.baseUrl("ers-returns")
 	lazy val validatorUrl: String = config.baseUrl("ers-file-validator")
 

--- a/app/views/includes/commonScriptElements.scala.html
+++ b/app/views/includes/commonScriptElements.scala.html
@@ -17,15 +17,6 @@
 @import config.ApplicationConfig
 @()(implicit appConfig: ApplicationConfig)
 
-<script type="text/javascript">
-                          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-                          (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-                          m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-                          })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-                         ga('create', '@appConfig.gaToken', 'auto');
-                          ga('send', 'pageview', { 'anonymizeIp': true });
-</script>
-
 <script src='@routes.Assets.at("javascripts/welsh_translation.js")'> </script>
 <script src='@routes.Assets.at("javascripts/ers_scripts.js")'> </script>
 <script src='@routes.Assets.at("javascripts/urBanner.js")'> </script>

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -32,16 +32,7 @@
 @import layouts._
 
 @head = {
-    @if(applicationConfig.googleTagManagerId != "N/A") {
-        <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-                    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-                j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-                'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-        })(window,document,'script','dataLayer','@applicationConfig.googleTagManagerId');
-        </script>
-    }
-
-    @uiLayouts.head(linkElem = linkElement, headScripts = None)
+    @uiLayouts.headWithTrackingConsent(linkElem = linkElement, headScripts = None)
     <meta name="format-detection" content="telephone=no"/>
 }
 
@@ -50,12 +41,6 @@
 }
 
 @insideHeader = {
-    @if(applicationConfig.googleTagManagerId != "N/A") {
-        <noscript>
-            <iframe src="https://www.googletagmanager.com/ns.html?id=@applicationConfig.googleTagManagerId" height="0" width="0" style="display: none;
-                visibility: hidden"></iframe>
-        </noscript>
-    }
 
 	@if(headerNav.isDefined) {
 	    @uiLayouts.header_nav(
@@ -82,8 +67,8 @@
 
 @bodyEnd = {
     @uiLayouts.footer(
-        analyticsToken = Option(applicationConfig.analyticsToken),
-        analyticsHost = applicationConfig.analyticsHost,
+        analyticsToken = None,
+        analyticsHost = "",
         ssoUrl = None,
         scriptElem = scriptElement,
         gaCalls = None

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -50,7 +50,7 @@ play {
     csrf {
       contentType.blackList = ["application/x-www-form-urlencoded", "multipart/form-data", "text/plain"]
     }
-    headers.contentSecurityPolicy= "default-src 'self' 'unsafe-inline' localhost:9032 localhost:9250 assets.digital.cabinet-office.gov.uk www.google-analytics.com www.googletagmanager.com fonts.googleapis.com tagmanager.google.com ssl.gstatic.com www.gstatic.com fonts.gstatic.co data:"
+    headers.contentSecurityPolicy= "default-src 'self' 'unsafe-inline' localhost:12345 localhost:9032 localhost:9250 assets.digital.cabinet-office.gov.uk www.google-analytics.com www.googletagmanager.com fonts.googleapis.com tagmanager.google.com ssl.gstatic.com www.gstatic.com fonts.gstatic.com data:"
   }
 }
 
@@ -89,14 +89,6 @@ assets {
 urBanner{
   toggle =  true
   link = "https://signup.take-part-in-research.service.gov.uk/?utm_campaign=ERS_confirmation&utm_source=Survey_Banner&utm_medium=other&t=HMRC&id=130"
-}
-
-govuk-tax {
-
-  google-analytics {
-    token = N/A
-    host = auto
-  }
 }
 
 auditing {
@@ -190,7 +182,7 @@ retry {
   delay = 2000
 }
 
-google-tag-manager {
-  id = "N/A"
+tracking-consent-frontend {
+  gtm.container = "c"
 }
 


### PR DESCRIPTION
# DDCE-1518

Migrate gtm over to tracking consent frontend implementation.
Also remove leftover old GA stuff as requested by Abdi
Guide used [here](https://confluence.tools.tax.service.gov.uk/display/PLATUI/Integrating+with+tracking+consent+-+a+guide+for+service+teams)

Many other PRs to merge before this one please:
https://github.com/hmrc/service-manager-config/pull/3283
https://github.com/hmrc/app-config-base/pull/5011
https://github.com/hmrc/app-config-staging/pull/7514
https://github.com/hmrc/app-config-qa/pull/10434
(None for prod yet as we need to wait for sign off before deploying there anyways)

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
 - [x]  I've squashed my commits - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date