### PR TITLE
[EH][DDCE-1911] Added server side file checks for non javascript users

### DIFF
--- a/app/models/upscan/UpscanInitiateRequest.scala
+++ b/app/models/upscan/UpscanInitiateRequest.scala
@@ -22,8 +22,9 @@ case class UpscanInitiateRequest(
                                   callbackUrl: String,
                                   successRedirect: String,
                                   errorRedirect: String,
-                                  minimumFileSize: Option[Int] = None,
-                                  maximumFileSize: Option[Int] = None
+                                  minimumFileSize: Int,
+                                  maximumFileSize: Int,
+                                  expectedContentType: Option[String] = None
                                 )
 
 object UpscanInitiateRequest {

--- a/app/services/UpscanService.scala
+++ b/app/services/UpscanService.scala
@@ -39,7 +39,7 @@ class UpscanService @Inject()(
 
     val success = controllers.routes.CsvFileUploadController.success(uploadId)
     val failure = controllers.routes.CsvFileUploadController.failure()
-    val upscanInitiateRequest = UpscanInitiateRequest(callback, urlToString(success), urlToString(failure))
+    val upscanInitiateRequest = UpscanInitiateRequest(callback, urlToString(success), urlToString(failure), 1, 104857600)
     upscanConnector.getUpscanFormData(upscanInitiateRequest)
   }
 
@@ -49,7 +49,7 @@ class UpscanService @Inject()(
 
     val success = controllers.routes.FileUploadController.success()
     val failure = controllers.routes.FileUploadController.failure()
-    val upscanInitiateRequest = UpscanInitiateRequest(callback, urlToString(success), urlToString(failure))
+    val upscanInitiateRequest = UpscanInitiateRequest(callback, urlToString(success), urlToString(failure), 1, 10485760)
     upscanConnector.getUpscanFormData(upscanInitiateRequest)
   }
 }

--- a/app/views/file_upload_problem.scala.html
+++ b/app/views/file_upload_problem.scala.html
@@ -1,0 +1,55 @@
+@*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import config.ApplicationConfig
+
+@this(
+        govuk_wrapper: govuk_wrapper,
+        hmrcPageHeading: HmrcPageHeading
+)
+
+@(pageTitle: String)(implicit request: Request[_], messages: Messages, appConfig: ApplicationConfig)
+
+@govuk_wrapper(title = messages(pageTitle)) {
+
+ @hmrcPageHeading(PageHeading(
+  text = messages("ers.file_problem.heading")
+ ))
+
+ <p class="govuk-body">@messages("ers.file_problem.paragraph")</p>
+ <ul class="govuk-list govuk-list--bullet">
+  <li>
+   @messages("ers.file_problem.invalidFileName")
+  </li>
+  <li>
+  @messages("ers.file_problem.fileTooLarge")
+  </li>
+  <li>
+  @messages("ers.file_problem.fileTooSmall")
+  </li>
+  <li>
+  @messages("ers.file_problem.invalidFileType")
+  </li>
+  <li>
+  @messages("ers.file_problem.invalidFileNameCharacters")
+  </li>
+ </ul>
+ <p class="govuk-body">
+  <a class="govuk-link" href="@routes.CheckFileTypeController.checkFileTypePage.url">
+   @messages("ers.file_problem.tryAgain")
+  </a>
+ </p>
+}

--- a/app/views/includes/upscan_file_upload_form.scala.html
+++ b/app/views/includes/upscan_file_upload_form.scala.html
@@ -44,7 +44,6 @@
     @govukFileUpload(FileUpload(
         name="file",
         id="fileToUpload",
-        classes = "govuk-!-display-none",
         attributes = Map("accept" -> s"$fileType"),
         label = Label(
             forAttr = Some("fileToUpload"),
@@ -59,8 +58,7 @@
     @govukButton(Button(
         inputType = Some("submit"),
         content = Text(messages("ers_group_file_check.check_file_button")),
-        attributes = Map("id" -> "submit"),
-        disabled = true
+        attributes = Map("id" -> "submit")
     ))
 
     <div class="govuk-!-display-none" id="progress-spinner"><img id="progress-spinner-img" src="@routes.Assets.versioned("images/spinner.gif")" alt="Loading ..."/></div>

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -596,3 +596,16 @@ ers.global.page.not.found.error.check.web.address.full=Os gwnaethoch ludo’r cy
 ers.global.page.not.found.error.contact=Os yw’r cyfeiriad gwe yn gywir neu os ydych wedi dewis cysylltiad neu fotwm, {0} os oes angen i chi siarad â rhywun am eich datganiad blynyddol.
 ers.global.page.not.found.error.contact.link.text=cysylltwch â Gwasanaeth Cwsmeriaid Cymraeg CThEM
 ers.global.page.not.found.error.contact.link=https://www.gov.uk/government/organisations/hm-revenue-customs/contact/welsh-language-helplines
+
+#********************************************************************
+# File problem messages
+#********************************************************************
+ers.file_problem.title = Bu problem wrth uwchlwytho’r ffeil - Gwarantau ar Sail Cyflogaeth – GOV.UK
+ers.file_problem.heading = Bu problem wrth uwchlwytho’r ffeil
+ers.file_problem.paragraph = Gall hyn fod oherwydd y canlynol:
+ers.file_problem.invalidFileName = mae gan y ffeil yr enw anghywir neu mae’r enw yn fwy na 240 o gymeriadau
+ers.file_problem.fileTooLarge = mae’r ffeil yn rhy fawr – mae terfyn o 100MB ar gyfer ffeiliau CSV a therfyn o 10MB ar gyfer ffeiliau ODS
+ers.file_problem.fileTooSmall = yn wag
+ers.file_problem.invalidFileType = mae’r ffeil wedi’i chadw ar ffurf anghywir – dylai fod ar ffurf CSV neu ODS yn dibynnu ar yr hyn rydych eisoes wedi’i ddewis
+ers.file_problem.invalidFileNameCharacters = mae’r ffeil yn cynnwys cymeriadau annilys
+ers.file_problem.tryAgain = Rhowch gynnig arall arni

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -735,6 +735,18 @@ ers.global_errors.heading = Submit your ERS annual return
 ers.global_errors.title = Sorry, there is a problem with the service - Submit your ERS annual return – GOV.UK
 ers.global.errors.try.later=Try again later.
 
+#********************************************************************
+# File problem messages
+#********************************************************************
+ers.file_problem.title = There is a problem with the file upload - Submit your ERS annual return – GOV.UK
+ers.file_problem.heading = There is a problem with the file upload
+ers.file_problem.paragraph = This may be because the file:
+ers.file_problem.invalidFileName = has the wrong name or the name is more than 240 characters
+ers.file_problem.fileTooLarge = is too large - there is a 100MB limit for CSV files and a 10MB limit for ODS files
+ers.file_problem.fileTooSmall = is empty
+ers.file_problem.invalidFileType = is the wrong type - it should be a CSV or an ODS depending on what you have already selected
+ers.file_problem.invalidFileNameCharacters = contains invalid characters
+ers.file_problem.tryAgain = Try again
 
 #********************************************************************
 # ur banner text

--- a/public/javascripts/file-upload.js
+++ b/public/javascripts/file-upload.js
@@ -13,9 +13,6 @@ const fileType = (function() {
     }
 })();
 
-// Only show file-upload input if JavaScript is enabled.
-fileUploadInput.classList.remove("govuk-!-display-none");
-
 function ensureUploadButtonIs(status) {
     if(status === "disabled") {
         if(uploadFileButton.attributes.getNamedItem("disabled") === null) {

--- a/test/connectors/UpscanConnectorSpec.scala
+++ b/test/connectors/UpscanConnectorSpec.scala
@@ -32,7 +32,7 @@ class UpscanConnectorSpec extends UnitSpec with OneAppPerSuite with MockitoSugar
 
 	lazy val connector: UpscanConnector = app.injector.instanceOf[UpscanConnector]
 	implicit val hc: HeaderCarrier = HeaderCarrier()
-	val request: UpscanInitiateRequest = UpscanInitiateRequest("callbackUrl", "successRedirectUrl", "errorRedirectUrl")
+	val request: UpscanInitiateRequest = UpscanInitiateRequest("callbackUrl", "successRedirectUrl", "errorRedirectUrl", 1, 104857600)
 	override def fakeApplication(): Application = new GuiceApplicationBuilder()
 		.configure(
 			"microservice.services.upscan.port" -> server.port()

--- a/test/services/UpscanServiceSpec.scala
+++ b/test/services/UpscanServiceSpec.scala
@@ -50,7 +50,7 @@ class UpscanServiceSpec extends UnitSpec with OneAppPerSuite with MockitoSugar {
       val callback = controllers.routes.FileUploadCallbackController.callback(hc.sessionId.get.value).absoluteURL()
       val success = controllers.routes.FileUploadController.success().absoluteURL()
       val failure = controllers.routes.FileUploadController.failure().absoluteURL()
-      val expectedInitiateRequest = UpscanInitiateRequest(callback, success, failure)
+      val expectedInitiateRequest = UpscanInitiateRequest(callback, success, failure, 1, 10485760)
 
       val upscanInitiateResponse = UpscanInitiateResponse(Reference("reference"), "postTarget", formFields = Map.empty[String, String])
       val initiateRequestCaptor = ArgumentCaptor.forClass(classOf[UpscanInitiateRequest])
@@ -73,7 +73,7 @@ class UpscanServiceSpec extends UnitSpec with OneAppPerSuite with MockitoSugar {
       val callback = controllers.routes.CsvFileUploadCallbackController.callback(uploadId, scRef).absoluteURL()
       val success = controllers.routes.CsvFileUploadController.success(uploadId).absoluteURL()
       val failure = controllers.routes.CsvFileUploadController.failure().absoluteURL()
-      val expectedInitiateRequest = UpscanInitiateRequest(callback, success, failure)
+      val expectedInitiateRequest = UpscanInitiateRequest(callback, success, failure, 1, 104857600)
 
       val upscanInitiateResponse = UpscanInitiateResponse(Reference("reference"), "postTarget", formFields = Map.empty[String, String])
       val initiateRequestCaptor = ArgumentCaptor.forClass(classOf[UpscanInitiateRequest])

--- a/test/utils/UpscanData.scala
+++ b/test/utils/UpscanData.scala
@@ -26,7 +26,8 @@ trait UpscanData {
 
   val testUploadId: UploadId = UploadId("TestUploadId")
   val notStartedCallback: UpscanCsvFilesCallback = UpscanCsvFilesCallback(testUploadId, "file4", NotStarted)
-  val uploadedSuccessfully = UploadedSuccessfully("fileName", "https://downloadUrl.com")
+  val uploadedSuccessfully = UploadedSuccessfully("fileName.ods", "https://downloadUrl.com")
+  val uploadedSuccessfullyCsv = UploadedSuccessfully("fileName.csv", "https://downloadUrl.com")
 
   val incompleteCsvList = UpscanCsvFilesCallbackList(
     List(


### PR DESCRIPTION
# DDCE-1911

- Updated the Upscan Initiate request with file size constraints
- I added the `expectedContentType`field to the `UpscanInitiateRequest` model but have not included this in the ods and csv initiate request as that functionality does not work as expected (Fix pending: https://jira.tools.tax.service.gov.uk/browse/BDOG-1394). This needs to be added at a later date.
- As a result, we check the file name (which includes the file extension) of the uploaded file against what we expected, before validating the document itself. If the file name and extension is wrong, the user is presented with a file upload problem page.
- Any upscan failure callback will also redirect to this page.
- Disabled Javascript restrictions have been removed.

### Pre-Merge Checklist

- [x] All welsh content received and updated

### Checklist

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
 - [x]  I've squashed my commits - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date