### PR TITLE
[DP][DDCE] Sanitise & character for PDF generation

### DIFF
--- a/app/config/ApplicationConfig.scala
+++ b/app/config/ApplicationConfig.scala
@@ -21,9 +21,10 @@ import controllers.routes
 import play.api.i18n.Lang
 import play.api.mvc.Call
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
-
 import javax.inject.Singleton
+
 import scala.concurrent.duration._
+import scala.util.matching.Regex
 
 @Singleton
 class ApplicationConfig @Inject()(config: ServicesConfig) {
@@ -87,5 +88,7 @@ class ApplicationConfig @Inject()(config: ServicesConfig) {
 	lazy val sessionCacheDomain: String = config.getString(s"microservice.services.cachable.session-cache.domain")
 
 	lazy val useNewValidator: Boolean = config.getBoolean("feature-flag.new-validator")
+
+	lazy val ampersandRegex: Regex = "(?!&amp;)(?:&)".r
 
 }

--- a/app/services/pdf/DecoratorController.scala
+++ b/app/services/pdf/DecoratorController.scala
@@ -16,20 +16,21 @@
 
 package services.pdf
 
+import javax.inject.Inject
 import models.{ErsSummary, TrusteeDetailsList}
 import play.api.i18n.Messages
-import utils.CountryCodes
+import utils.{CountryCodes, ERSUtil}
 
 import scala.collection.mutable.ListBuffer
 
-class DecoratorController(val decorators: Array[Decorator]) {
+class DecoratorController@Inject()(val decorators: Array[Decorator])(implicit ERSUtil: ERSUtil) {
 
 	def addDecorator(decorator: Decorator): DecoratorController = new DecoratorController(decorators :+ decorator)
 
 	def decorate(implicit messages: Messages): String = {
-		val html = decorators.map(decorator => decorator.decorate).mkString
-		"(?:&)(?!&amp;)".r
-			.replaceAllIn(html, "&amp;")
+		ERSUtil.replaceAmpersand(
+			decorators.map(decorator => decorator.decorate).mkString
+		)
 	}
 
 	def addFileNamesDecorator(filesUploaded: Option[ListBuffer[String]], ersSummary: ErsSummary): DecoratorController = {

--- a/app/services/pdf/ErsReceiptPdfBuilderService.scala
+++ b/app/services/pdf/ErsReceiptPdfBuilderService.scala
@@ -19,20 +19,19 @@ package services.pdf
 import models.ErsSummary
 import play.api.Logging
 import play.api.i18n.Messages
-import utils.{ContentUtil, CountryCodes, DateUtils}
+import utils.{ContentUtil, CountryCodes, DateUtils, ERSUtil}
 import java.io.{ByteArrayOutputStream, File}
 
-import com.openhtmltopdf.pdfboxout.{PDFontSupplier, PdfRendererBuilder}
+import com.openhtmltopdf.pdfboxout.PdfRendererBuilder
 import com.openhtmltopdf.svgsupport.BatikSVGDrawer
 import javax.inject.{Inject, Singleton}
 import org.apache.commons.io.IOUtils
-import org.apache.pdfbox.pdmodel.font.PDType1Font
 
 import scala.collection.mutable.ListBuffer
 import scala.io.Source
 
 @Singleton
-class ErsReceiptPdfBuilderService @Inject()(val countryCodes: CountryCodes) extends PdfDecoratorControllerFactory with Logging {
+class ErsReceiptPdfBuilderService @Inject()(val countryCodes: CountryCodes)(implicit val ERSUtil: ERSUtil) extends PdfDecoratorControllerFactory with Logging {
 
   def createPdf(ersSummary: ErsSummary,
                 filesUploaded: Option[ListBuffer[String]],
@@ -67,8 +66,9 @@ class ErsReceiptPdfBuilderService @Inject()(val countryCodes: CountryCodes) exte
   }
 
   def addMetaData(ersSummary: ErsSummary, dateSubmitted: String)(implicit messages: Messages): String = {
-
-    s"""<h1 style="padding-top: 3em;">${messages("ers.pdf.title")}</h1>
+    ERSUtil.replaceAmpersand(
+      s"""
+       |<h1 style="padding-top: 3em;">${messages("ers.pdf.title")}</h1>
        |
        |<p style="padding-bottom: 1em; font-size: 14pt;">${messages("ers.pdf.confirmation.submitted", ContentUtil.getSchemeAbbreviation(ersSummary.metaData.schemeInfo.schemeType))}</p>
        |<div style="display: block;">
@@ -94,6 +94,7 @@ class ErsReceiptPdfBuilderService @Inject()(val countryCodes: CountryCodes) exte
        |</div>
        |</footer>
        |""".stripMargin
+    )
   }
 
   def pdfHeader(implicit messages: Messages): String = {

--- a/app/services/pdf/PdfDecoratorControllerFactory.scala
+++ b/app/services/pdf/PdfDecoratorControllerFactory.scala
@@ -18,7 +18,7 @@ package services.pdf
 
 import models.{AlterationAmends, ErsSummary}
 import play.api.i18n.Messages
-import utils.{CountryCodes, PageBuilder}
+import utils.{CountryCodes, ERSUtil, PageBuilder}
 
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
@@ -26,6 +26,7 @@ import scala.collection.mutable.ListBuffer
 trait PdfDecoratorControllerFactory extends PageBuilder {
 
 	val countryCodes: CountryCodes
+	implicit val ERSUtil: ERSUtil
 
   def createPdfDecoratorControllerForScheme(scheme: String, ersSummary: ErsSummary, filesUploaded: Option[ListBuffer[String]])
 																					 (implicit messages: Messages): DecoratorController = {

--- a/app/utils/ERSUtil.scala
+++ b/app/utils/ERSUtil.scala
@@ -332,4 +332,9 @@ class ERSUtil @Inject()(val sessionService: SessionService,
 	def addCompanyMessage(messages: Messages, schemeOpt: Option[String]): String = {
 		messages.apply(s"ers_group_summary.${schemeOpt.getOrElse("").toLowerCase}.add_company")
 	}
+
+	def replaceAmpersand(input: String): String = {
+		appConfig.ampersandRegex
+			.replaceAllIn(input, "&amp;")
+	}
 }

--- a/test/services/ErsReceiptPdfBuilderServiceSpec.scala
+++ b/test/services/ErsReceiptPdfBuilderServiceSpec.scala
@@ -17,6 +17,8 @@
 package services
 
 import akka.stream.Materializer
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 import org.scalatest.{BeforeAndAfterEach, OptionValues}
@@ -27,7 +29,7 @@ import play.api.i18n.{MessagesApi, MessagesImpl}
 import play.api.mvc.{AnyContent, DefaultActionBuilder, DefaultMessagesControllerComponents, MessagesControllerComponents}
 import play.api.test.Helpers.stubBodyParser
 import services.pdf.ErsReceiptPdfBuilderService
-import utils.{ContentUtil, ERSFakeApplicationConfig, ErsTestHelper, Fixtures}
+import utils.{ContentUtil, ERSFakeApplicationConfig, ERSUtil, ErsTestHelper, Fixtures}
 
 import scala.concurrent.ExecutionContext
 
@@ -51,11 +53,13 @@ class ErsReceiptPdfBuilderServiceSpec extends AnyWordSpecLike
   )
 
   implicit lazy val mat: Materializer = app.materializer
+  implicit val ersUtil: ERSUtil = mockErsUtil
 	val testErsReceiptPdfBuilderService = new ErsReceiptPdfBuilderService(mockCountryCodes)
   implicit lazy val testMessages: MessagesImpl = MessagesImpl(i18n.Lang("en"), mockMCC.messagesApi)
 
   "ErsReceiptPdfBuilderService" should {
     "generate the ERS summary metdata" in {
+      when(mockErsUtil.replaceAmpersand(any[String])).thenAnswer(_.getArgument(0))
 			val output = testErsReceiptPdfBuilderService.addMetaData(Fixtures.ersSummary, "12 August 2016, 4:28pm")
 
       val expectedConfirmationMessage = s"Your ${ContentUtil.getSchemeAbbreviation("emi")} annual return has been submitted."

--- a/test/services/pdf/PdfDecoratorControllerFactorySpec.scala
+++ b/test/services/pdf/PdfDecoratorControllerFactorySpec.scala
@@ -27,7 +27,7 @@ import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.i18n.{Messages, MessagesApi}
 import play.api.mvc.{AnyContent, DefaultActionBuilder, DefaultMessagesControllerComponents, MessagesControllerComponents}
 import play.api.test.Helpers.stubBodyParser
-import utils.{CountryCodes, ERSFakeApplicationConfig, ErsTestHelper, Fixtures}
+import utils.{CountryCodes, ERSFakeApplicationConfig, ERSUtil, ErsTestHelper, Fixtures}
 
 import scala.concurrent.ExecutionContext
 
@@ -51,10 +51,11 @@ class PdfDecoratorControllerFactorySpec extends AnyWordSpecLike
 
   implicit lazy val mat: Materializer = app.materializer
 
-	class TestPdfDecoratorControllerFactory extends PdfDecoratorControllerFactory {
-		val mockCountryCodes: CountryCodes = mock[CountryCodes]
-		override val countryCodes: CountryCodes = mockCountryCodes
-	}
+  class TestPdfDecoratorControllerFactory extends PdfDecoratorControllerFactory {
+    val mockCountryCodes: CountryCodes = mock[CountryCodes]
+    override val countryCodes: CountryCodes = mockCountryCodes
+    override val ERSUtil: ERSUtil = new ERSUtil(mockSessionCache, mockShortLivedCache, mockAppConfig)(ec, mockCountryCodes)
+  }
 
   lazy val altAmends: AlterationAmends = AlterationAmends(altAmendsTerms = Some("1"),
     altAmendsEligibility = Some("1"),

--- a/test/utils/ErsTestHelper.scala
+++ b/test/utils/ErsTestHelper.scala
@@ -102,6 +102,7 @@ trait ErsTestHelper extends MockitoSugar with AuthHelper with ERSFakeApplication
 	when(mockAppConfig.odsSuccessRetryAmount).thenReturn(5)
 	when(mockAppConfig.odsValidationRetryAmount).thenReturn(1)
 	when(mockAppConfig.urBannerLink).thenReturn("http://")
+	when(mockAppConfig.ampersandRegex).thenReturn("(?!&amp;)(?:&)".r)
 
 	import scala.concurrent.duration._
 	when(mockAppConfig.retryDelay).thenReturn(3 milliseconds)

--- a/test/utils/ErsUtilSpec.scala
+++ b/test/utils/ErsUtilSpec.scala
@@ -530,4 +530,23 @@ class ErsUtilSpec extends AnyWordSpecLike
       assert(ersUtil.buildAddressSummary(3.14) == expected)
     }
   }
+
+  "calling replaceAmpersand" should {
+    val ersUtil: ERSUtil = new ERSUtil(mockSessionCache, mockShortLivedCache, mockAppConfig)
+
+    "do nothing to a string with no ampersands" in {
+      val input = "I am some test input"
+      ersUtil.replaceAmpersand(input) shouldBe "I am some test input"
+    }
+
+    "replace any ampersands with &amp;" in {
+      val input = "I am some test input & stuff &"
+      ersUtil.replaceAmpersand(input) shouldBe "I am some test input &amp; stuff &amp;"
+    }
+
+    "not affect any &amp; that already exists" in {
+      val input = "I am some test input & stuff &amp;"
+      ersUtil.replaceAmpersand(input) shouldBe "I am some test input &amp; stuff &amp;"
+    }
+  }
 }


### PR DESCRIPTION
Spotted in monitoring, PDF fails to generate if the company name has the `&` character

Previous fix was only for company address fields, it did not work if the company name itself had the `&` character. This fixes that and all other fields just in case