### PR TITLE
DDCE-2385 - Use Referer to go back on the add a trustee page

### DIFF
--- a/app/views/govuk_wrapper.scala.html
+++ b/app/views/govuk_wrapper.scala.html
@@ -35,7 +35,7 @@
 
 @head = {
     <meta name="format-detection" content="telephone=no"/>
-    <link rel="stylesheet" href="assets/css/ers.css">
+    <link rel="stylesheet" href="assets/css/ers.css" type="text/css" @{CSPNonce.attr}>
     @if(!disableSignOut) {
         @hmrcTimeoutDialogHelper(
             signOutUrl = applicationConfig.signOut,

--- a/app/views/trustee_details.scala.html
+++ b/app/views/trustee_details.scala.html
@@ -49,7 +49,7 @@
 
     @govukBackLink(BackLink(
         content = Text(messages("ers.back")),
-        href = ersUtil.getPageBackLink(schemeId, ersUtil.PAGE_TRUSTEE_DETAILS, groupSchemeActivity),
+        href = request.headers.get("Referer").getOrElse(ersUtil.getPageBackLink(schemeId, ersUtil.PAGE_TRUSTEE_DETAILS, groupSchemeActivity))
     ))
 
     @if(trusteeDetails.hasErrors) {

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -16,7 +16,7 @@ object AppDependencies {
     "uk.gov.hmrc"                 %%    "http-caching-client"           %   "9.6.0-play-28",
     "uk.gov.hmrc"                 %%    "play-language"                 %   "5.2.0-play-28",
     "uk.gov.hmrc"                 %%    "time"                          %   "3.25.0",
-    "uk.gov.hmrc"                 %%    "play-frontend-hmrc"            %   "3.7.0-play-28",
+    "uk.gov.hmrc"                 %%    "play-frontend-hmrc"            %   "3.9.0-play-28",
     "org.scala-lang.modules"      %%    "scala-parser-combinators"      %   "2.1.1",
     "org.apache.pdfbox"           %     "pdfbox"                        %   pdfboxVersion,
     "org.apache.pdfbox"           %     "xmpbox"                        %   pdfboxVersion,


### PR DESCRIPTION
# DDCE-2385 - Use Referer to go back on the add a trustee page

+ve: meets the acceptance criteria - `Back button takes the user back to the previous location they visited the page from`

-ve: On the summary page, when clicking the back link each time, we end up in a loop, i.e. trustee-summary -> add a trustee -> trustee summary.
