### PR TITLE
DDCE-2385 - Use browser history to go back

### DIFF
--- a/app/views/govuk_wrapper.scala.html
+++ b/app/views/govuk_wrapper.scala.html
@@ -35,7 +35,7 @@
 
 @head = {
     <meta name="format-detection" content="telephone=no"/>
-    <link rel="stylesheet" href="assets/css/ers.css">
+    <link rel="stylesheet" href="assets/css/ers.css" type="text/css" @{CSPNonce.attr}>
     @if(!disableSignOut) {
         @hmrcTimeoutDialogHelper(
             signOutUrl = applicationConfig.signOut,

--- a/app/views/trustee_details.scala.html
+++ b/app/views/trustee_details.scala.html
@@ -40,7 +40,7 @@
 @schemeId = @{requestObject.getSchemeId}
 
 @scripts = {
-    <script type="text/javascript" src='@controllers.routes.Assets.versioned("javascripts/trustee-uk-or-overseas-form-reveal.js")' @{CSPNonce.attr}></script>
+    <script type="text/javascript" src='@controllers.routes.Assets.versioned("javascripts/iebacklink.js")' @{CSPNonce.attr}></script>
 }
 
 @govuk_wrapper(title = messages("ers.add_trustee.page_title"), Some(scripts)) {
@@ -48,8 +48,7 @@
     @reference(requestObject.getPageTitle)
 
     @govukBackLink(BackLink(
-        content = Text(messages("ers.back")),
-        href = ersUtil.getPageBackLink(schemeId, ersUtil.PAGE_TRUSTEE_DETAILS, groupSchemeActivity),
+        attributes = Map("id" -> "back-link"), classes="js-enabled", content = HtmlContent(messages("ers.back"))
     ))
 
     @if(trusteeDetails.hasErrors) {

--- a/app/views/trustee_summary.scala.html
+++ b/app/views/trustee_summary.scala.html
@@ -18,6 +18,7 @@
 @import _root_.utils.ERSUtil
 @import config.ApplicationConfig
 @import views.html.templates.reference
+@import views.html.helper.CSPNonce
 
 @this(
         govuk_wrapper: govuk_wrapper,
@@ -100,13 +101,15 @@
     trusteeNameSummary ++ trusteeLocationSummary ++ addressSummary
 }
 
-@govuk_wrapper(title = messages("ers.trustees.page_title")) {
+@scripts = {
+    <script type="text/javascript" src='@controllers.routes.Assets.versioned("javascripts/iebacklink.js")' @{CSPNonce.attr}></script>
+}
+@govuk_wrapper(title = messages("ers.trustees.page_title"), Some(scripts)) {
 
     @reference(requestObject.getPageTitle)
 
     @govukBackLink(BackLink(
-        content = Text(messages("ers.back")),
-        href = routes.TrusteeController.trusteeDetailsPage.url,
+        attributes = Map("id" -> "back-link"), classes="js-enabled", content = HtmlContent(messages("ers.back"))
     ))
 
     @hmrcPageHeading(PageHeading(

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -16,7 +16,7 @@ object AppDependencies {
     "uk.gov.hmrc"                 %%    "http-caching-client"           %   "9.6.0-play-28",
     "uk.gov.hmrc"                 %%    "play-language"                 %   "5.2.0-play-28",
     "uk.gov.hmrc"                 %%    "time"                          %   "3.25.0",
-    "uk.gov.hmrc"                 %%    "play-frontend-hmrc"            %   "3.7.0-play-28",
+    "uk.gov.hmrc"                 %%    "play-frontend-hmrc"            %   "3.9.0-play-28",
     "org.scala-lang.modules"      %%    "scala-parser-combinators"      %   "2.1.1",
     "org.apache.pdfbox"           %     "pdfbox"                        %   pdfboxVersion,
     "org.apache.pdfbox"           %     "xmpbox"                        %   pdfboxVersion,

--- a/public/javascripts/iebacklink.js
+++ b/public/javascripts/iebacklink.js
@@ -1,0 +1,10 @@
+// prevent resubmit warning
+if (window.history && window.history.replaceState && typeof window.history.replaceState === 'function') {
+    window.history.replaceState(null, null, window.location.href);
+}
+
+const backLink = document.getElementById("back-link")
+backLink.addEventListener('click', function(e){
+    e.preventDefault();
+    window.history.back();
+});


### PR DESCRIPTION
# DDCE-2385 - Use browser history to go back

Copied how trusts FE apps use the back link via the browser history.

+ve: Meets the A/C - `Back button takes the user back to the previous location they visited the page from`
         
-ve: Can be non-intuitive since the page after the summary page does not use the browser history, clicking the back link multiple times will get the pages incorrect, but it won't be a never ending loop as PR-#145. To get around this, It may be possible to get all the back links on all pages to use the browser history rather than explicit routings or [this back link logic](https://github.com/hmrc/ers-returns-frontend/blob/7e9d33e77089540b7f990ee8de574654c617a148/app/utils/PageBuilder.scala#L175-L316). This could be a much bigger piece of work that would need a BA to figure out the importance of replacing the coded back link logic.