### PR TITLE
DDCE-5373: Update HMRC logo

### DIFF
--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -6,14 +6,14 @@ object AppDependencies {
   val pdfboxVersion    = "2.0.30"
   val openHtmlVersion  = "1.0.10"
   val bootstrapVersion = "7.23.0"
-  val mongoVersion     = "1.3.0"
+  val mongoVersion     = "1.7.0"
 
   val compile: Seq[ModuleID] = Seq(
     guice,
     ws,
     "uk.gov.hmrc"             %% "bootstrap-frontend-play-28" % bootstrapVersion,
     "uk.gov.hmrc.mongo"       %% "hmrc-mongo-play-28"         % mongoVersion,
-    "uk.gov.hmrc"             %% "play-frontend-hmrc"         % "7.29.0-play-28",
+    "uk.gov.hmrc"             %% "play-frontend-hmrc-play-28" % "8.5.0",
     "uk.gov.hmrc"             %% "play-partials"              % "8.4.0-play-28",
     "uk.gov.hmrc"             %% "domain"                     % "8.3.0-play-28",
     "org.apache.pdfbox"       %  "pdfbox"                     % pdfboxVersion,
@@ -23,18 +23,18 @@ object AppDependencies {
     "com.openhtmltopdf"       %  "openhtmltopdf-core"         % openHtmlVersion,
     "com.openhtmltopdf"       %  "openhtmltopdf-pdfbox"       % openHtmlVersion,
     "com.openhtmltopdf"       %  "openhtmltopdf-svg-support"  % openHtmlVersion,
-    "commons-codec"           %  "commons-codec"              % "1.16.0"
+    "commons-codec"           %  "commons-codec"              % "1.16.1"
   )
 
   val test: Seq[ModuleID]      = Seq(
     "uk.gov.hmrc"             %% "bootstrap-test-play-28"  % bootstrapVersion,
     "uk.gov.hmrc.mongo"       %% "hmrc-mongo-test-play-28" % mongoVersion,
-    "org.scalatest"           %% "scalatest"               % "3.2.17",
-    "org.scalatestplus"       %% "mockito-4-11"            % "3.2.17.0",
+    "org.scalatest"          %% "scalatest"              % "3.2.18",
+    "org.scalatestplus"      %% "mockito-5-10"           % "3.2.18.0",
     "com.vladsch.flexmark"    %  "flexmark-all"            % "0.64.8",
     "org.pegdown"             %  "pegdown"                 % "1.6.0",
-    "org.jsoup"               %  "jsoup"                   % "1.17.2",
-    "org.wiremock"            % "wiremock-standalone"      % "3.3.1"
+    "org.jsoup"              %  "jsoup"                  % "1.17.2",
+    "org.wiremock"            % "wiremock-standalone"      % "3.4.2"
 
   ).map(_ % Test)
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -12,6 +12,6 @@ addSbtPlugin("uk.gov.hmrc"         % "sbt-distributables"         % "2.4.0")
 addSbtPlugin("uk.gov.hmrc"         % "sbt-accessibility-linter"   % "0.37.0")
 addSbtPlugin("com.typesafe.play"   % "sbt-plugin"                 % "2.8.21")
 addSbtPlugin("org.scoverage"       % "sbt-scoverage"              % "2.0.9")
-addSbtPlugin("com.beautiful-scala" % "sbt-scalastyle"             % "1.5.1")
+addSbtPlugin("org.scalastyle"      % "scalastyle-sbt-plugin"      % "1.0.0")
 addSbtPlugin("com.timushev.sbt"    % "sbt-updates"                % "0.6.4")
 

--- a/test/controllers/CsvFileUploadControllerSpec.scala
+++ b/test/controllers/CsvFileUploadControllerSpec.scala
@@ -166,11 +166,11 @@ class CsvFileUploadControllerSpec
 
   "success" should {
     "update the cache for the relevant uploadId to InProgress" in {
-      val updatedCallbackCaptor: ArgumentCaptor[UpscanCsvFilesCallbackList] =
-        ArgumentCaptor.forClass(classOf[UpscanCsvFilesCallbackList])
+      val updatedCallbackCaptor: ArgumentCaptor[UpscanCsvFilesList] =
+        ArgumentCaptor.forClass(classOf[UpscanCsvFilesList])
       when(mockSessionService.fetch[UpscanCsvFilesList](meq("csv-files-upload"))(any(), any()))
         .thenReturn(Future.successful(notStartedUpscanCsvFilesList))
-      when(mockSessionService.cache(meq("csv-files-upload"), updatedCallbackCaptor.capture())(any(), any()))
+      when(mockSessionService.cache[UpscanCsvFilesList](meq("csv-files-upload"), updatedCallbackCaptor.capture())(any(), any()))
         .thenReturn(Future.successful(sessionPair))
 
       await(csvFileUploadController.success(testUploadId)(testFakeRequest))

--- a/test/services/FrontendSessionServiceSpec.scala
+++ b/test/services/FrontendSessionServiceSpec.scala
@@ -369,7 +369,7 @@ class FrontendSessionServiceSpec extends AnyWordSpec with Matchers with ErsTestH
       val testData = "testData"
       val expectedResponse = ("cacheId", "key")
 
-      when(frontendSessionsRepository.putSession[String](DataKey(eqTo(key)), eqTo(testData))(any(), any(), any()))
+      when(frontendSessionsRepository.putSession[String](DataKey(eqTo(key)), eqTo(testData))(any(), any()))
         .thenReturn(Future.successful(expectedResponse))
 
       val result = testService.cache(key, testData).futureValue
@@ -381,7 +381,7 @@ class FrontendSessionServiceSpec extends AnyWordSpec with Matchers with ErsTestH
       val testData = "testData"
       val exception = new RuntimeException("Cache operation failed")
 
-      when(frontendSessionsRepository.putSession[String](DataKey(eqTo(key)), eqTo(testData))(any(), any(), any()))
+      when(frontendSessionsRepository.putSession[String](DataKey(eqTo(key)), eqTo(testData))(any(), any()))
         .thenReturn(Future.failed(exception))
 
       val result = testService.cache(key, testData).failed.futureValue


### PR DESCRIPTION
# DDCE-5373

update to use dependency "uk.gov.hmrc" %% "play-frontend-hmrc-play-28" % "8.5.0" which uses new HMRC logo:
<img width="1046" alt="Screenshot 2024-02-27 at 15 47 53" src="https://github.com/hmrc/ers-returns-frontend/assets/125281117/9571b05d-86e2-47cb-96a1-454ff6a19890">

