### PR TITLE
DDCE-6057: vulnerability fix

### DIFF
--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -24,7 +24,8 @@ object AppDependencies {
     "com.openhtmltopdf"       %  "openhtmltopdf-pdfbox"       % openHtmlVersion,
     "com.openhtmltopdf"       %  "openhtmltopdf-svg-support"  % openHtmlVersion,
     "commons-codec"           %  "commons-codec"              % "1.17.1",
-    "org.codehaus.janino"     %  "janino"                     % "3.1.12"
+    "org.codehaus.janino"     %  "janino"                     % "3.1.12",
+    "commons-io"              % "commons-io"                  % "2.18.0"
   )
 
   val test: Seq[ModuleID]      = Seq(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy2", url("https://open.artefact
   Resolver.ivyStylePatterns
 )
 
-addSbtPlugin("uk.gov.hmrc"         %  "sbt-auto-build"            % "3.22.0")
+addSbtPlugin("uk.gov.hmrc"         %  "sbt-auto-build"            % "3.24.0")
 addSbtPlugin("uk.gov.hmrc"         %% "sbt-distributables"        % "2.5.0")
 addSbtPlugin("uk.gov.hmrc"         %  "sbt-accessibility-linter"  % "1.0.0")
 addSbtPlugin("org.playframework"   %% "sbt-plugin"                % "3.0.5")


### PR DESCRIPTION
# DDCE-6057: vulnerability fix
- Vulnerability fix by adding this lib commons-io temp, which is not directly dependent on batik-codec