### PR TITLE
DDCE-2158: Add file size logging for both ODS and CSV files

### DIFF
--- a/app/controllers/FileUploadController.scala
+++ b/app/controllers/FileUploadController.scala
@@ -54,7 +54,7 @@ class FileUploadController @Inject() (val mcc: MessagesControllerComponents,
   def uploadFilePage(): Action[AnyContent] = authAction.async { implicit request =>
     (for {
       requestObject <- sessionService.fetch[RequestObject](ersUtil.ERS_REQUEST_OBJECT)
-      response <- upscanService.getUpscanFormDataOds
+      response <- upscanService.getUpscanFormDataOds(requestObject.getSchemeReference)
       _ <- ersConnector.createCallbackRecord
     } yield Ok(upscanOdsFileUploadView(requestObject, response))) recover { case e: Throwable =>
       logger.error(s"[FileUploadController][uploadFilePage] failed with exception ${e.getMessage}, timestamp: ${System.currentTimeMillis()}.", e)

--- a/app/controllers/internal/FileSizeUtils.scala
+++ b/app/controllers/internal/FileSizeUtils.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.internal
+
+import play.api.Logging
+import services.audit.AuditEvents
+import uk.gov.hmrc.http.HeaderCarrier
+
+import javax.inject.Inject
+
+case class FileSizeUtils @Inject()(val auditEvents: AuditEvents) extends Logging {
+
+  def logFileSize(schemeRef: String, fileSize: Int)(implicit hc: HeaderCarrier): Unit = {
+    auditEvents.auditFileSize(schemeRef, fileSize.toString)
+    logger.info(s"[FileSizeUtils][logFileSize]: schemeRef: ${schemeRef}, size: ${mapFileSizeToString(fileSize)}")
+  }
+
+  def mapFileSizeToString(fileSize: Int): String = {
+    val numberBytesInUnit = 1024.0
+    fileSize match {
+      case size: Int if size < numberBytesInUnit =>
+        f"$size%.2f bytes"
+      case size: Int if (Math.pow(numberBytesInUnit, 2.0) > size && size >= numberBytesInUnit) =>
+        val fileSizeInKb = size / numberBytesInUnit
+        f"${fileSizeInKb}%.2f KB (${fileSize} bytes)"
+      case size: Int if (Math.pow(numberBytesInUnit, 3.0) > size && size >= Math.pow(numberBytesInUnit, 2.0)) =>
+        val fileSizeInMb = size / Math.pow(numberBytesInUnit, 2.0)
+        f"${fileSizeInMb}%.2f MB (${fileSize} bytes)"
+      case size: Int if size >= Math.pow(numberBytesInUnit, 3.0) =>
+        val fileSizeInMb = size / Math.pow(numberBytesInUnit, 3.0)
+        f"${fileSizeInMb}%.2f GB (${fileSize} bytes)"
+    }
+  }
+
+}

--- a/app/models/upscan/UpscanCallback.scala
+++ b/app/models/upscan/UpscanCallback.scala
@@ -67,6 +67,6 @@ object UpscanCallback {
     }
 }
 
-case class UploadDetails(uploadTimestamp: Instant, checksum: String, fileMimeType: String, fileName: String)
+case class UploadDetails(uploadTimestamp: Instant, checksum: String, fileMimeType: String, fileName: String, size: Int)
 
 case class ErrorDetails(failureReason: String, message: String)

--- a/app/services/UpscanService.scala
+++ b/app/services/UpscanService.scala
@@ -51,10 +51,10 @@ class UpscanService @Inject()(applicationConfig: ApplicationConfig, upscanConnec
     upscanConnector.getUpscanFormData(upscanInitiateRequest)
   }
 
-  def getUpscanFormDataOds(implicit hc: HeaderCarrier, request: Request[_]): Future[UpscanInitiateResponse] = {
+  def getUpscanFormDataOds(scRef: String)(implicit hc: HeaderCarrier, request: Request[_]): Future[UpscanInitiateResponse] = {
     val callbackUrl = generateCallbackUrl(
       hc.sessionId,
-      sessionId => controllers.internal.routes.FileUploadCallbackController.callback(sessionId),
+      sessionId => controllers.internal.routes.FileUploadCallbackController.callback(scRef, sessionId),
       isSecure)
 
     val success = controllers.routes.FileUploadController.success()

--- a/app/services/audit/AuditEvents.scala
+++ b/app/services/audit/AuditEvents.scala
@@ -29,6 +29,15 @@ import scala.concurrent.{ExecutionContext, Future}
 class AuditEvents @Inject() (val auditConnector: DefaultAuditConnector)(implicit val ec: ExecutionContext)
     extends AuditService {
 
+  def auditFileSize(schemeRef: String, fileSize: String)(implicit hc: HeaderCarrier): Future[AuditResult] =
+    sendEvent(
+      "UploadFileSizeFromUpscanCallback",
+      Map(
+        "schemeRef" -> schemeRef,
+        "fileSize" -> fileSize
+      )
+    )
+
   def auditRunTimeError(exception: Throwable, contextInfo: String, rsc: ErsMetaData, bundle: String)(implicit
     hc: HeaderCarrier
   ): Unit =

--- a/conf/internal.routes
+++ b/conf/internal.routes
@@ -1,4 +1,4 @@
 #Internal routes
 
-POST        /file-upload/callback                           controllers.internal.FileUploadCallbackController.callback(sessionId: String)
+POST        /file-upload/callback                           controllers.internal.FileUploadCallbackController.callback(scRef: String, sessionId: String)
 POST        /csv-file-upload/callback                       controllers.internal.CsvFileUploadCallbackController.callback(uploadId: UploadId, scRef: String, sessionId: String)

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -5,7 +5,7 @@ object AppDependencies {
 
   val pdfboxVersion    = "2.0.32"
   val openHtmlVersion  = "1.0.10"
-  val bootstrapVersion = "9.5.0"
+  val bootstrapVersion = "9.7.0"
   val mongoVersion     = "2.2.0"
 
   val compile: Seq[ModuleID] = Seq(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,7 +6,7 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy2", url("https://open.artefact
 addSbtPlugin("uk.gov.hmrc"         %  "sbt-auto-build"            % "3.24.0")
 addSbtPlugin("uk.gov.hmrc"         %% "sbt-distributables"        % "2.5.0")
 addSbtPlugin("uk.gov.hmrc"         %  "sbt-accessibility-linter"  % "1.0.0")
-addSbtPlugin("org.playframework"   %% "sbt-plugin"                % "3.0.5")
+addSbtPlugin("org.playframework"   %% "sbt-plugin"                % "3.0.6")
 addSbtPlugin("org.scoverage"       %% "sbt-scoverage"             % "2.0.12")
 addSbtPlugin("org.scalastyle"      %% "scalastyle-sbt-plugin"     % "1.0.0" exclude("org.scala-lang.modules", "scala-xml_2.12"))
 addSbtPlugin("com.timushev.sbt"    %  "sbt-updates"               % "0.6.4")

--- a/test/controllers/FileUploadControllerSpec.scala
+++ b/test/controllers/FileUploadControllerSpec.scala
@@ -139,7 +139,7 @@ class FileUploadControllerSpec
       .thenReturn(Future.successful(ersRequestObject))
     "return OK" when {
       "Upscan form data is successfully returned and callback record is created in session cache" in {
-        when(mockUpscanService.getUpscanFormDataOds(any[HeaderCarrier], any[Request[_]]))
+        when(mockUpscanService.getUpscanFormDataOds(anyString())(any[HeaderCarrier], any[Request[_]]))
           .thenReturn(Future.successful(upscanInitiateResponse))
         when(mockErsConnector.createCallbackRecord(any(), any()))
           .thenReturn(Future.successful(CREATED))
@@ -154,7 +154,7 @@ class FileUploadControllerSpec
       "Upscan service returns an exception retrieving form data" in {
         reset(mockErsConnector)
         setAuthMocks()
-        when(mockUpscanService.getUpscanFormDataOds(any[HeaderCarrier], any[Request[_]]))
+        when(mockUpscanService.getUpscanFormDataOds(anyString())(any[HeaderCarrier], any[Request[_]]))
           .thenReturn(Future.failed(new Exception("Expected exception")))
         when(mockSessionService.fetch[RequestObject](meq(ERS_REQUEST_OBJECT))(any(), any()))
           .thenReturn(Future.successful(ersRequestObject))
@@ -166,7 +166,7 @@ class FileUploadControllerSpec
       }
 
       "Session service returns an exception creating callback record" in {
-        when(mockUpscanService.getUpscanFormDataOds(any[HeaderCarrier], any[Request[_]]))
+        when(mockUpscanService.getUpscanFormDataOds(anyString())(any[HeaderCarrier], any[Request[_]]))
           .thenReturn(Future.successful(upscanInitiateResponse))
         when(mockErsConnector.createCallbackRecord(any(), any()))
           .thenReturn(Future.failed(new Exception("Expected exception")))

--- a/test/controllers/internal/FileSizeUtilsSpec.scala
+++ b/test/controllers/internal/FileSizeUtilsSpec.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.internal
+
+import org.mockito.ArgumentCaptor
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.{times, verify}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+import org.scalatestplus.mockito.MockitoSugar
+import services.audit.AuditEvents
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.play.audit.DefaultAuditConnector
+import uk.gov.hmrc.play.audit.model.DataEvent
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class FileSizeUtilsSpec
+  extends AnyWordSpecLike
+  with Matchers
+  with MockitoSugar {
+
+  val mockAuditConnector: DefaultAuditConnector = mock[DefaultAuditConnector]
+  val mockAuditEvents: AuditEvents = new AuditEvents(mockAuditConnector)
+  implicit val hc: HeaderCarrier = HeaderCarrier()
+  val fileSizeUtils: FileSizeUtils = new FileSizeUtils(mockAuditEvents)
+
+  "logFileSize" should {
+    "audit the file size with the scheme ref" in {
+      fileSizeUtils.logFileSize("1234", 100)
+      val eventCaptor = ArgumentCaptor.forClass(classOf[DataEvent])
+      verify(mockAuditConnector, times(1)).sendEvent(eventCaptor.capture())(any(), any())
+      eventCaptor.getValue.asInstanceOf[DataEvent].auditSource shouldBe "ers-returns-frontend"
+      eventCaptor.getValue.asInstanceOf[DataEvent].auditType shouldBe "UploadFileSizeFromUpscanCallback"
+      eventCaptor.getValue.asInstanceOf[DataEvent].detail shouldBe Map("schemeRef" -> "1234", "fileSize" -> "100")
+    }
+  }
+
+  "mapFileSizeToString" should {
+    val fileSizeInBytesAndExpectedString: Seq[(Int, String)] = Seq(
+      (10, "10.00 bytes"),
+      (99, "99.00 bytes"),
+      (100, "100.00 bytes"),
+      (1000, "1000.00 bytes"),
+      (1024, "1.00 KB (1024 bytes)"),
+      (1126, "1.10 KB (1126 bytes)"),
+      (524288, "512.00 KB (524288 bytes)"),
+      (1048575, "1024.00 KB (1048575 bytes)"),
+      (1048576, "1.00 MB (1048576 bytes)"),
+      (1153433, "1.10 MB (1153433 bytes)"),
+      (107374182, "102.40 MB (107374182 bytes)"),
+      (1073741823, "1024.00 MB (1073741823 bytes)"),
+      (1073741824, "1.00 GB (1073741824 bytes)"),
+      (1181116006, "1.10 GB (1181116006 bytes)")
+    )
+
+    fileSizeInBytesAndExpectedString.foreach {
+      fileSizeAndExpectedString: (Int, String) =>
+        s"return the expected string: ${fileSizeAndExpectedString._2} when parsed a file size of: ${fileSizeAndExpectedString._1}" in {
+          fileSizeUtils.mapFileSizeToString(fileSizeAndExpectedString._1) shouldBe fileSizeAndExpectedString._2
+        }
+    }
+  }
+}

--- a/test/services/UpscanServiceSpec.scala
+++ b/test/services/UpscanServiceSpec.scala
@@ -51,13 +51,14 @@ class UpscanServiceSpec
 
   def upscanService: UpscanService = app.injector.instanceOf[UpscanService]
   val mockUpscanConnector: UpscanConnector = mock[UpscanConnector]
+  val schemeRef = "schemeRef"
 
   "getUpscanFormDataOds" must {
     "get form data from Upscan Connector with an initiate request" in {
       implicit val request: Request[_] = FakeRequest("GET", "http://localhost:9290/")
       val hc = HeaderCarrier(sessionId = Some(SessionId("sessionid")))
       val callback =
-        controllers.internal.routes.FileUploadCallbackController.callback(hc.sessionId.get.value).absoluteURL()
+        controllers.internal.routes.FileUploadCallbackController.callback(schemeRef, hc.sessionId.get.value).absoluteURL()
       val success = controllers.routes.FileUploadController.success().absoluteURL()
       val failure = controllers.routes.FileUploadController.failure().absoluteURL()
       val expectedInitiateRequest = UpscanInitiateRequest(callback, success, failure, 1, 10485760)
@@ -69,7 +70,7 @@ class UpscanServiceSpec
       when(mockUpscanConnector.getUpscanFormData(initiateRequestCaptor.capture())(any[HeaderCarrier]))
         .thenReturn(Future.successful(upscanInitiateResponse))
 
-      upscanService.getUpscanFormDataOds(hc, request).futureValue
+      upscanService.getUpscanFormDataOds(schemeRef)(hc, request).futureValue
 
       initiateRequestCaptor.getAllValues contains expectedInitiateRequest
     }

--- a/test/utils/UpscanData.scala
+++ b/test/utils/UpscanData.scala
@@ -75,7 +75,7 @@ trait UpscanData {
     )
   )
 
-  val uploadDetails  = UploadDetails(Instant.now(), "checksum", "fileMimeType", "fileName")
+  val uploadDetails  = UploadDetails(Instant.now(), "checksum", "fileMimeType", "fileName", 100)
   val readyCallback  = UpscanReadyCallback(Reference("Reference"), new URL("https://callbackUrl.com"), uploadDetails)
   val failedCallback = UpscanFailedCallback(Reference("Reference"), ErrorDetails("failureReason", "message"))
 


### PR DESCRIPTION
# DDCE-2158
- Add file size for both csv and ods file uploads
- The file size is logged out after the file is successfully uploaded to Upscan

## Testing locally

For multiple csv files in the same journey, each file has its size logged out independently: 
```scala anotate
[FileSizeUtils][logFileSize]: schemeRef: XA1100000000000, size: 59.00 bytes
[FileSizeUtils][logFileSize]: schemeRef: XA1100000000000, size: 142.00 bytes
```
Looking locally the two CSV files size matches what is logged out above:
`59B  CSOP_OptionsGranted_V4.csv`
`142B CSOP_OptionsExercised_V4.csv`

For ods:
```scala anotate
[FileSizeUtils][logFileSize]: schemeRef: XA1100000000000, size: 8.24 KB (8433 bytes)
```
Looking locally the ODS file size matches what is logged out above: `8.2K CSOP_template_2023-24_V4.ods`, multi tab ods files produce one log line containing the file size.