### PR TITLE
DDCE-6989 remove sbt-accessibility-linter plugin

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -165,10 +165,6 @@ sessionTimeout {
 
 contact-frontend.serviceId = "ers-returns"
 
-sbt-accessibility-linter {
-  output-format = "concise"
-}
-
 mongodb {
     uri = "mongodb://localhost:27017/ers-returns-frontend"
     userSessionsCacheTTL = 1.hour

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -3,8 +3,8 @@ import sbt.*
 
 object AppDependencies {
   val openHtmlVersion  = "1.1.31"
-  val bootstrapVersion = "9.19.0"
-  val mongoVersion     = "2.7.0"
+  val bootstrapVersion = "10.2.0"
+  val mongoVersion     = "2.9.0"
 
   val compile: Seq[ModuleID] = Seq(
     "uk.gov.hmrc"             %% "bootstrap-frontend-play-30" % bootstrapVersion,
@@ -19,7 +19,7 @@ object AppDependencies {
     "io.github.openhtmltopdf" %  "openhtmltopdf-svg-support"  % openHtmlVersion
   )
 
-  val test: Seq[ModuleID]      = Seq(
+  private val test: Seq[ModuleID]      = Seq(
     "uk.gov.hmrc"             %% "bootstrap-test-play-30"  % bootstrapVersion,
     "uk.gov.hmrc.mongo"       %% "hmrc-mongo-test-play-30" % mongoVersion
   ).map(_ % Test)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,7 +5,6 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy2", url("https://open.artefact
 
 addSbtPlugin("uk.gov.hmrc"         %  "sbt-auto-build"            % "3.24.0")
 addSbtPlugin("uk.gov.hmrc"         %% "sbt-distributables"        % "2.6.0")
-addSbtPlugin("uk.gov.hmrc"         %  "sbt-accessibility-linter"  % "1.0.0")
 addSbtPlugin("org.playframework"   %% "sbt-plugin"                % "3.0.8")
 addSbtPlugin("org.scoverage"       %% "sbt-scoverage"             % "2.3.1")
 addSbtPlugin("com.timushev.sbt"    %  "sbt-updates"               % "0.6.4")


### PR DESCRIPTION
# DDCE-6989

Remove sbt-accessibility-linter plugin, a11y tests were already removed in previous commit [here](https://github.com/hmrc/ers-returns-frontend/commit/bf993ff741d6788bf0f741181ab0203989089a69)

