### PR TITLE
DDCE-8784: Add logging to show csv radio button selected

### DIFF
--- a/app/controllers/CsvFileUploadController.scala
+++ b/app/controllers/CsvFileUploadController.scala
@@ -29,6 +29,7 @@ import services.audit.AuditEvents
 import services.{FrontendSessionService, UpscanService}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.mongo.cache.DataKey
+import uk.gov.hmrc.play.audit.http.connector.AuditResult
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import utils._
 
@@ -74,7 +75,7 @@ class CsvFileUploadController @Inject() (
         csvFilesList.ids.map((upscanIds: UpscanIds) =>
           ersUtil.getFileName(upscanIds.fileId, requestObject.getSchemeId, useCsopV5Templates(requestObject.taxYear))
         )
-      _                               <- auditEvents.auditSelectedCsvRadioButtons(allSelectedCsvFiles)
+      _                                = auditEvents.auditSelectedCsvRadioButtons(allSelectedCsvFiles)
       _                                =
         logger.info(
           s"[CsvFileUploadController][uploadFilePage] The following files were selected to be uploaded: ${allSelectedCsvFiles.mkString(", ")}"

--- a/app/controllers/CsvFileUploadController.scala
+++ b/app/controllers/CsvFileUploadController.scala
@@ -66,11 +66,19 @@ class CsvFileUploadController @Inject() (
       )
     }
     (for {
-      requestObject  <- sessionService.fetch[RequestObject](ersUtil.ERS_REQUEST_OBJECT)
-      csvFilesList   <- sessionService.fetch[UpscanCsvFilesList](ersUtil.CSV_FILES_UPLOAD)
-      currentCsvFile  = csvFilesList.ids.find(ids => ids.uploadStatus == NotStarted)
+      requestObject                   <- sessionService.fetch[RequestObject](ersUtil.ERS_REQUEST_OBJECT)
+      csvFilesList                    <- sessionService.fetch[UpscanCsvFilesList](ersUtil.CSV_FILES_UPLOAD)
+      allSelectedCsvFiles: Seq[String] =
+        csvFilesList.ids.map((upscanIds: UpscanIds) =>
+          ersUtil.getFileName(upscanIds.fileId, requestObject.getSchemeId, useCsopV5Templates(requestObject.taxYear))
+        )
+      _                                = logger.info(
+                                           s"[CsvFileUploadController][uploadFilePage] The following " +
+                                             s"files were selected to be uploaded: ${allSelectedCsvFiles.mkString(", ")}"
+                                         )
+      currentCsvFile                   = csvFilesList.ids.find(ids => ids.uploadStatus == NotStarted)
       if currentCsvFile.isDefined
-      upscanFormData <-
+      upscanFormData                  <-
         upscanService.getUpscanFormDataCsv(currentCsvFile.get.uploadId, requestObject.getSchemeReference)
     } yield Ok(
       upscanCsvFileUploadView(

--- a/app/controllers/CsvFileUploadController.scala
+++ b/app/controllers/CsvFileUploadController.scala
@@ -25,6 +25,7 @@ import org.apache.pekko.actor.ActorSystem
 import play.api.Logging
 import play.api.i18n.{I18nSupport, Messages}
 import play.api.mvc._
+import services.audit.AuditEvents
 import services.{FrontendSessionService, UpscanService}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.mongo.cache.DataKey
@@ -41,6 +42,7 @@ class CsvFileUploadController @Inject() (
   val ersConnector: ErsConnector,
   val upscanService: UpscanService,
   val sessionService: FrontendSessionService,
+  val auditEvents: AuditEvents,
   globalErrorView: views.html.global_error,
   upscanCsvFileUploadView: views.html.upscan_csv_file_upload,
   fileSizeLimitErrorView: views.html.file_size_limit_error,
@@ -61,7 +63,7 @@ class CsvFileUploadController @Inject() (
   def uploadFilePage(): Action[AnyContent] = authAction.async { implicit request =>
     sessionService.fetch[ErsMetaData](ersUtil.ERS_METADATA).map { ele =>
       logger.info(
-        s"[CsvFileUploadController][uploadFilePage()] Fetched request object with SAP Number: ${ele.sapNumber} " +
+        s"[CsvFileUploadController][uploadFilePage] Fetched request object with SAP Number: ${ele.sapNumber} " +
           s"and schemeRef: ${ele.schemeInfo.schemeRef}"
       )
     }
@@ -72,10 +74,11 @@ class CsvFileUploadController @Inject() (
         csvFilesList.ids.map((upscanIds: UpscanIds) =>
           ersUtil.getFileName(upscanIds.fileId, requestObject.getSchemeId, useCsopV5Templates(requestObject.taxYear))
         )
-      _                                = logger.info(
-                                           s"[CsvFileUploadController][uploadFilePage] The following " +
-                                             s"files were selected to be uploaded: ${allSelectedCsvFiles.mkString(", ")}"
-                                         )
+      _                               <- auditEvents.auditSelectedCsvRadioButtons(allSelectedCsvFiles)
+      _                                =
+        logger.info(
+          s"[CsvFileUploadController][uploadFilePage] The following files were selected to be uploaded: ${allSelectedCsvFiles.mkString(", ")}"
+        )
       currentCsvFile                   = csvFilesList.ids.find(ids => ids.uploadStatus == NotStarted)
       if currentCsvFile.isDefined
       upscanFormData                  <-

--- a/app/services/audit/AuditEvents.scala
+++ b/app/services/audit/AuditEvents.scala
@@ -29,6 +29,14 @@ import scala.concurrent.{ExecutionContext, Future}
 class AuditEvents @Inject() (val auditConnector: DefaultAuditConnector)(implicit val ec: ExecutionContext)
     extends AuditService {
 
+  def auditSelectedCsvRadioButtons(selectedCsvFiles: Seq[String])(implicit hc: HeaderCarrier): Future[AuditResult] =
+    sendEvent(
+      "SelectedCsvRadioButtons",
+      Map(
+        "selectedCsvFiles" -> selectedCsvFiles.mkString(", ")
+      )
+    )
+
   def auditFileSize(schemeRef: String, fileSize: String)(implicit hc: HeaderCarrier): Future[AuditResult] =
     sendEvent(
       "UploadFileSizeFromUpscanCallback",

--- a/app/utils/ERSUtil.scala
+++ b/app/utils/ERSUtil.scala
@@ -107,4 +107,11 @@ class ERSUtil @Inject() (val appConfig: ApplicationConfig)(implicit
     appConfig.ampersandRegex
       .replaceAllIn(input, "&amp;")
 
+  def getFileName(fileId: String, schemeId: String, useCsopV5Templates: Boolean)(implicit messages: Messages): String =
+    if (schemeId == "1" && useCsopV5Templates) {
+      getPageElement(schemeId, PAGE_CHECK_CSV_FILE, s"$fileId.file_name.v5")
+    } else {
+      getPageElement(schemeId, PAGE_CHECK_CSV_FILE, s"$fileId.file_name")
+    }
+
 }

--- a/app/views/includes/upscan_file_upload_form.scala.html
+++ b/app/views/includes/upscan_file_upload_form.scala.html
@@ -36,13 +36,7 @@
         useCsopV5Templates: Boolean = false
 )(implicit messages: Messages, ersUtil: ERSUtil)
 
-@expectedFileName = @{
-    if (schemeId == "1" && useCsopV5Templates) {
-        ersUtil.getPageElement(schemeId, ersUtil.PAGE_CHECK_CSV_FILE,fileId+".file_name.v5")
-    } else {
-        ersUtil.getPageElement(schemeId, ersUtil.PAGE_CHECK_CSV_FILE,fileId+".file_name")
-    }
-}
+@expectedFileName = @{ersUtil.getFileName(fileId, schemeId, useCsopV5Templates)}
 
 @* Derive message key for warning text from file type *@
 @csvOrOdsFileTypeKey = @{fileType.substring(1).toUpperCase}

--- a/test/controllers/CsvFileUploadControllerSpec.scala
+++ b/test/controllers/CsvFileUploadControllerSpec.scala
@@ -89,7 +89,7 @@ class CsvFileUploadControllerSpec
 
   val mockUpscanService: UpscanService      = mock[UpscanService]
   val ersUtil: ERSUtil                      = new ERSUtil(mockAppConfig)
-  val CsvFileUploadControllerLogger: Logger = Logger(classOf[CsvFileUploadController])
+  val csvFileUploadControllerLogger: Logger = Logger(classOf[CsvFileUploadController])
 
   lazy val csvFileUploadController: CsvFileUploadController =
     new CsvFileUploadController(
@@ -108,7 +108,7 @@ class CsvFileUploadControllerSpec
       testAuthAction
     )(ec, ersUtil = ersUtil, mockAppConfig, mockActorSystem) {
       override lazy val allCsvFilesCacheRetryAmount: Int = 1
-      override val logger: Logger                        = CsvFileUploadControllerLogger
+      override val logger: Logger                        = csvFileUploadControllerLogger
     }
 
   override def beforeEach(): Unit =
@@ -202,7 +202,7 @@ class CsvFileUploadControllerSpec
       when(mockSessionService.fetch[UpscanCsvFilesList](meq("csv-files-upload"))(any(), any()))
         .thenReturn(Future.successful(UpscanCsvFilesList(upscanIds)))
 
-      withCaptureOfLoggingFrom(CsvFileUploadControllerLogger) { captureEvents =>
+      withCaptureOfLoggingFrom(csvFileUploadControllerLogger) { captureEvents =>
         await(csvFileUploadController.uploadFilePage()(testFakeRequest))
         assert(captureEvents.exists(_.getMessage.contains(expectedLogMessage)))
       }
@@ -231,7 +231,7 @@ class CsvFileUploadControllerSpec
       when(mockSessionService.fetch[UpscanCsvFilesList](meq("csv-files-upload"))(any(), any()))
         .thenReturn(Future.successful(UpscanCsvFilesList(upscanIds)))
 
-      withCaptureOfLoggingFrom(CsvFileUploadControllerLogger) { captureEvents =>
+      withCaptureOfLoggingFrom(csvFileUploadControllerLogger) { captureEvents =>
         await(csvFileUploadController.uploadFilePage()(testFakeRequest))
         assert(captureEvents.exists(_.getMessage.contains(expectedLogMessage)))
       }

--- a/test/controllers/CsvFileUploadControllerSpec.scala
+++ b/test/controllers/CsvFileUploadControllerSpec.scala
@@ -30,7 +30,7 @@ import org.scalatest.wordspec.AnyWordSpecLike
 import org.scalatest.{BeforeAndAfterEach, OptionValues}
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
-import play.api.i18n
+import play.api.{Logger, i18n}
 import play.api.i18n.{MessagesApi, MessagesImpl}
 import play.api.libs.json.{JsObject, Json}
 import play.api.mvc._
@@ -48,6 +48,8 @@ import java.time.Instant
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Random
 import org.mockito.ArgumentMatchers.{eq => eqTo}
+import uk.gov.hmrc.play.audit.http.connector.AuditResult.Success
+import uk.gov.hmrc.play.bootstrap.tools.LogCapturing
 
 class CsvFileUploadControllerSpec
     extends AnyWordSpecLike
@@ -59,7 +61,8 @@ class CsvFileUploadControllerSpec
     with UpscanData
     with ScalaFutures
     with ErsTestHelper
-    with GuiceOneAppPerSuite {
+    with GuiceOneAppPerSuite
+    with LogCapturing {
 
   val mockMCC: MessagesControllerComponents = DefaultMessagesControllerComponents(
     messagesActionBuilder,
@@ -84,7 +87,9 @@ class CsvFileUploadControllerSpec
   lazy val wrongCsvFileTypeView: views.html.wrong_csv_file_type =
     app.injector.instanceOf[views.html.wrong_csv_file_type]
 
-  val mockUpscanService: UpscanService = mock[UpscanService]
+  val mockUpscanService: UpscanService      = mock[UpscanService]
+  val ersUtil: ERSUtil                      = new ERSUtil(mockAppConfig)
+  val CsvFileUploadControllerLogger: Logger = Logger(classOf[CsvFileUploadController])
 
   lazy val csvFileUploadController: CsvFileUploadController =
     new CsvFileUploadController(
@@ -92,6 +97,7 @@ class CsvFileUploadControllerSpec
       mockErsConnector,
       mockUpscanService,
       mockSessionService,
+      mockAuditEvents,
       globalErrorView,
       upscanCsvFileUploadView,
       fileSizeLimitErrorView,
@@ -100,17 +106,24 @@ class CsvFileUploadControllerSpec
       invalidMimeError,
       wrongCsvFileTypeView,
       testAuthAction
-    ) {
+    )(ec, ersUtil = ersUtil, mockAppConfig, mockActorSystem) {
       override lazy val allCsvFilesCacheRetryAmount: Int = 1
+      override val logger: Logger                        = CsvFileUploadControllerLogger
     }
 
-  override def beforeEach(): Unit = {
-    when(mockErsUtil.CSV_FILES_UPLOAD).thenReturn("csv-files-upload")
-    when(mockErsUtil.CHECK_CSV_FILES).thenReturn("check-csv-files")
-    when(mockSessionService.fetch[RequestObject](any())(any(), any()))
-      .thenReturn(Future.successful(ersRequestObject))
+  override def beforeEach(): Unit =
     setAuthMocks()
-  }
+
+  when(mockSessionService.fetch[RequestObject](refEq(mockErsUtil.ERS_REQUEST_OBJECT))(any(), any()))
+    .thenReturn(Future.successful(ersRequestObject))
+
+  when(
+    mockSessionService.fetch[ErsMetaData](refEq(mockErsUtil.ERS_METADATA))(any(), any())
+  ).thenReturn(
+    Future.successful(ErsMetaData(SchemeInfo("", Instant.now, "", "", "", ""), "", None, "", None, None))
+  )
+
+  when(mockAuditEvents.auditSelectedCsvRadioButtons(any())(any())).thenReturn(Future.successful(Success))
 
   "uploadFilePage" should {
     "display file upload page" when {
@@ -171,6 +184,62 @@ class CsvFileUploadControllerSpec
         status(result)        shouldBe INTERNAL_SERVER_ERROR
         contentAsString(result) should include(testMessages("ers.global_errors.title"))
       }
+    }
+
+    val upscanIds: List[UpscanIds] = List(
+      UpscanIds(UploadId("123"), "file0", NotStarted),
+      UpscanIds(UploadId("456"), "file1", NotStarted),
+      UpscanIds(UploadId("789"), "file2", NotStarted)
+    )
+
+    "log the selected csv files" in {
+
+      when(mockAppConfig.csopV5Enabled).thenReturn(false)
+
+      val expectedLogMessage = "[CsvFileUploadController][uploadFilePage] The following files were selected to be " +
+        "uploaded: Other_Grants_V4.csv, Other_Options_V4.csv, Other_Acquisition_V4.csv"
+
+      when(mockSessionService.fetch[UpscanCsvFilesList](meq("csv-files-upload"))(any(), any()))
+        .thenReturn(Future.successful(UpscanCsvFilesList(upscanIds)))
+
+      withCaptureOfLoggingFrom(CsvFileUploadControllerLogger) { captureEvents =>
+        await(csvFileUploadController.uploadFilePage()(testFakeRequest))
+        assert(captureEvents.exists(_.getMessage.contains(expectedLogMessage)))
+      }
+
+      verify(mockAuditEvents, times(1)).auditSelectedCsvRadioButtons(
+        meq(List("Other_Grants_V4.csv", "Other_Options_V4.csv", "Other_Acquisition_V4.csv"))
+      )(any())
+    }
+
+    "log the selected csv files for v5 tax years" in {
+
+      when(mockAppConfig.csopV5Enabled).thenReturn(true)
+
+      val csopV5RequestObject = ersRequestObject.copy(
+        taxYear = Some("2024/25"),
+        schemeName = Some("Csop"),
+        schemeType = Some("CSOP")
+      )
+
+      when(mockSessionService.fetch[RequestObject](refEq(mockErsUtil.ERS_REQUEST_OBJECT))(any(), any()))
+        .thenReturn(Future.successful(csopV5RequestObject))
+
+      val expectedLogMessage = "[CsvFileUploadController][uploadFilePage] The following files were selected to be " +
+        "uploaded: CSOP_OptionsGranted_V5.csv, CSOP_OptionsRCL_V5.csv, CSOP_OptionsExercised_V5.csv"
+
+      when(mockSessionService.fetch[UpscanCsvFilesList](meq("csv-files-upload"))(any(), any()))
+        .thenReturn(Future.successful(UpscanCsvFilesList(upscanIds)))
+
+      withCaptureOfLoggingFrom(CsvFileUploadControllerLogger) { captureEvents =>
+        await(csvFileUploadController.uploadFilePage()(testFakeRequest))
+        assert(captureEvents.exists(_.getMessage.contains(expectedLogMessage)))
+      }
+
+      verify(mockAuditEvents, times(1)).auditSelectedCsvRadioButtons(
+        meq(List("CSOP_OptionsGranted_V5.csv", "CSOP_OptionsRCL_V5.csv", "CSOP_OptionsExercised_V5.csv"))
+      )(any())
+
     }
   }
 
@@ -294,6 +363,7 @@ class CsvFileUploadControllerSpec
         mockErsConnector,
         mockUpscanService,
         mockSessionService,
+        mockAuditEvents,
         globalErrorView,
         upscanCsvFileUploadView,
         fileSizeLimitErrorView,
@@ -374,6 +444,7 @@ class CsvFileUploadControllerSpec
         mockErsConnector,
         mockUpscanService,
         mockSessionService,
+        mockAuditEvents,
         globalErrorView,
         upscanCsvFileUploadView,
         fileSizeLimitErrorView,
@@ -413,6 +484,7 @@ class CsvFileUploadControllerSpec
         mockErsConnector,
         mockUpscanService,
         mockSessionService,
+        mockAuditEvents,
         globalErrorView,
         upscanCsvFileUploadView,
         fileSizeLimitErrorView,
@@ -491,6 +563,7 @@ class CsvFileUploadControllerSpec
         mockErsConnector,
         mockUpscanService,
         mockSessionService,
+        mockAuditEvents,
         globalErrorView,
         upscanCsvFileUploadView,
         fileSizeLimitErrorView,
@@ -558,6 +631,7 @@ class CsvFileUploadControllerSpec
         mockErsConnector,
         mockUpscanService,
         mockSessionService,
+        mockAuditEvents,
         globalErrorView,
         upscanCsvFileUploadView,
         fileSizeLimitErrorView,
@@ -772,6 +846,7 @@ class CsvFileUploadControllerSpec
         mockErsConnector,
         mockUpscanService,
         mockSessionService,
+        mockAuditEvents,
         globalErrorView,
         upscanCsvFileUploadView,
         fileSizeLimitErrorView,
@@ -855,6 +930,7 @@ class CsvFileUploadControllerSpec
         mockErsConnector,
         mockUpscanService,
         mockSessionService,
+        mockAuditEvents,
         globalErrorView,
         upscanCsvFileUploadView,
         fileSizeLimitErrorView,


### PR DESCRIPTION
Add logging for selected csv radio buttons, example log:
```
[CsvFileUploadController][uploadFilePage] The following files were selected to be uploaded: CSOP_OptionsGranted_V4.csv, CSOP_OptionsRCL_V4.csv
```

Add audit message. 

Add tests which check log message and audit log.

Refactored small bit of html.