### PR TITLE
DDCE-8829: Improve retry logging

### DIFF
--- a/app/controllers/CsvFileUploadController.scala
+++ b/app/controllers/CsvFileUploadController.scala
@@ -29,7 +29,6 @@ import services.audit.AuditEvents
 import services.{FrontendSessionService, UpscanService}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.mongo.cache.DataKey
-import uk.gov.hmrc.play.audit.http.connector.AuditResult
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import utils._
 

--- a/app/controllers/CsvFileUploadController.scala
+++ b/app/controllers/CsvFileUploadController.scala
@@ -187,7 +187,7 @@ class CsvFileUploadController @Inject() (
             case (_, _)                                                     => None
           }
         }
-        .withRetry(allCsvFilesCacheRetryAmount)(_.isDefined)
+        .withRetry(allCsvFilesCacheRetryAmount, Some(schemeInfo), "extractCsvCallbackData")(_.isDefined)
         .flatMap { files =>
           val csvFilesCallbackList: UpscanCsvFilesCallbackList = UpscanCsvFilesCallbackList(files.get)
           sessionService.cache(ersUtil.CHECK_CSV_FILES, csvFilesCallbackList).flatMap { _ =>

--- a/app/controllers/FileUploadController.scala
+++ b/app/controllers/FileUploadController.scala
@@ -72,7 +72,7 @@ class FileUploadController @Inject() (
 
   def success(): Action[AnyContent] = authAction.async { implicit request =>
     val futureCallbackData: Future[Option[UploadStatus]] =
-      ersConnector.getCallbackRecord.withRetry(appConfig.odsSuccessRetryAmount) { opt =>
+      ersConnector.getCallbackRecord.withRetry(appConfig.odsSuccessRetryAmount, callingFunc = "success") { opt =>
         opt.fold(true) {
           case _: UploadedSuccessfully | Failed => true
           case _                                => false
@@ -132,9 +132,10 @@ class FileUploadController @Inject() (
   }
 
   def validationResults(): Action[AnyContent] = authAction.async { implicit request =>
-    val futureCallbackData = ersConnector.getCallbackRecord.withRetry(appConfig.odsValidationRetryAmount)(
-      _.exists(_.isInstanceOf[UploadedSuccessfully])
-    )
+    val futureCallbackData =
+      ersConnector.getCallbackRecord.withRetry(appConfig.odsValidationRetryAmount, callingFunc = "validationResults")(
+        _.exists(_.isInstanceOf[UploadedSuccessfully])
+      )
 
     (for {
       all                <- sessionService.fetch[ErsMetaData](ersUtil.ERS_METADATA)

--- a/app/utils/Retryable.scala
+++ b/app/utils/Retryable.scala
@@ -17,6 +17,7 @@
 package utils
 
 import config.ApplicationConfig
+import models.SchemeInfo
 import org.apache.pekko.actor.{ActorSystem, Scheduler}
 import org.apache.pekko.pattern.after
 import play.api.Logging
@@ -33,12 +34,15 @@ trait Retryable extends Logging {
   implicit class RetryCache[A](f: => Future[A]) {
 
     def withRetry(
-      maxTimes: Int
+      maxTimes: Int,
+      maybeSchemeInfo: Option[SchemeInfo] = None,
+      callingFunc: String
     )(pToBreakLoop: A => Boolean)(implicit actorSystem: ActorSystem, ec: ExecutionContext): Future[A] = {
       val delay: FiniteDuration                                       = appConfig.retryDelay
       val scheduler: Scheduler                                        = actorSystem.getScheduler
+      val schemeRef                                            = maybeSchemeInfo.map(_.schemeRef).getOrElse("NOT DEFINED")
       def loop(count: Int = 0, previous: Option[A] = None): Future[A] = {
-        logger.info(s"Retrying call x$count")
+        logger.info(s"[$callingFunc][withRetry] Retrying call x$count, schemeRef: $schemeRef")
         if (count < maxTimes) {
           f.flatMap { data =>
             if (pToBreakLoop(data)) {
@@ -48,6 +52,8 @@ trait Retryable extends Logging {
             }
           }
         } else {
+          // Logging "EXHAUSTED MAX NUMBER OF RETRIES" will cause alert to be triggered
+          logger.info(s"[$callingFunc][withRetry] EXHAUSTED MAX NUMBER OF RETRIES ($maxTimes times), schemeRef: $schemeRef")
           throw LoopException(count, previous)
         }
       }

--- a/app/utils/Retryable.scala
+++ b/app/utils/Retryable.scala
@@ -40,7 +40,7 @@ trait Retryable extends Logging {
     )(pToBreakLoop: A => Boolean)(implicit actorSystem: ActorSystem, ec: ExecutionContext): Future[A] = {
       val delay: FiniteDuration                                       = appConfig.retryDelay
       val scheduler: Scheduler                                        = actorSystem.getScheduler
-      val schemeRef                                            = maybeSchemeInfo.map(_.schemeRef).getOrElse("NOT DEFINED")
+      val schemeRef                                                   = maybeSchemeInfo.map(_.schemeRef).getOrElse("NOT DEFINED")
       def loop(count: Int = 0, previous: Option[A] = None): Future[A] = {
         logger.info(s"[$callingFunc][withRetry] Retrying call x$count, schemeRef: $schemeRef")
         if (count < maxTimes) {
@@ -53,7 +53,9 @@ trait Retryable extends Logging {
           }
         } else {
           // Logging "EXHAUSTED MAX NUMBER OF RETRIES" will cause alert to be triggered
-          logger.info(s"[$callingFunc][withRetry] EXHAUSTED MAX NUMBER OF RETRIES ($maxTimes times), schemeRef: $schemeRef")
+          logger.info(
+            s"[$callingFunc][withRetry] EXHAUSTED MAX NUMBER OF RETRIES ($maxTimes times), schemeRef: $schemeRef"
+          )
           throw LoopException(count, previous)
         }
       }

--- a/app/utils/Retryable.scala
+++ b/app/utils/Retryable.scala
@@ -40,9 +40,9 @@ trait Retryable extends Logging {
     )(pToBreakLoop: A => Boolean)(implicit actorSystem: ActorSystem, ec: ExecutionContext): Future[A] = {
       val delay: FiniteDuration                                       = appConfig.retryDelay
       val scheduler: Scheduler                                        = actorSystem.getScheduler
-      val schemeRef                                                   = maybeSchemeInfo.map(_.schemeRef).getOrElse("NOT DEFINED")
+      val schemeRef                                                   = maybeSchemeInfo.map(_.schemeRef).getOrElse("<<NOT DEFINED>>")
       def loop(count: Int = 0, previous: Option[A] = None): Future[A] = {
-        logger.info(s"[$callingFunc][withRetry] Retrying call x$count, schemeRef: $schemeRef")
+        logger.info(s"[Retryable][withRetry] - [$callingFunc] call x$count, schemeRef: $schemeRef")
         if (count < maxTimes) {
           f.flatMap { data =>
             if (pToBreakLoop(data)) {
@@ -54,7 +54,7 @@ trait Retryable extends Logging {
         } else {
           // Logging "EXHAUSTED MAX NUMBER OF RETRIES" will cause alert to be triggered
           logger.info(
-            s"[$callingFunc][withRetry] EXHAUSTED MAX NUMBER OF RETRIES ($maxTimes times), schemeRef: $schemeRef"
+            s"[Retryable][withRetry] - [$callingFunc] EXHAUSTED_MAX_NUMBER_OF_RETRIES ($maxTimes times), schemeRef: $schemeRef"
           )
           throw LoopException(count, previous)
         }

--- a/test/utils/RetryableSpec.scala
+++ b/test/utils/RetryableSpec.scala
@@ -121,7 +121,6 @@ class RetryableSpec
         withCaptureOfLoggingFrom(retryTestLogger) { captureEvents =>
           val error: LoopException[Boolean] = intercept[LoopException[Boolean]] {
             await(retryMock.f.withRetry(3, maybeSchemeInfo = Some(schemeInfo), callingFunc = "RetryableSpec")(b => b), 1, SECONDS)
-//            retryMock.f.withRetry(3, maybeSchemeInfo = Some(schemeInfo), callingFunc = "RetryableSpec")(b => b).futureValue
           }
           assert(error == LoopException(3, Some(false)))
           assert(error.getMessage == "Failed to meet predicate after retrying 3 times.")

--- a/test/utils/RetryableSpec.scala
+++ b/test/utils/RetryableSpec.scala
@@ -17,28 +17,40 @@
 package utils
 
 import config.ApplicationConfig
+import controllers.CsvFileUploadController
+import models.SchemeInfo
 import org.apache.pekko.actor.ActorSystem
 import org.mockito.Mockito.{times, verify, when}
 import org.scalatest.OptionValues
+import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.Logger
 import play.api.test.Helpers.await
+import uk.gov.hmrc.play.bootstrap.tools.LogCapturing
 
+import java.time.Instant
 import scala.concurrent.Future
 import scala.concurrent.duration.SECONDS
 
 class RetryableSpec
     extends AnyWordSpecLike
-    with Matchers
-    with OptionValues
-    with MockitoSugar
-    with GuiceOneAppPerSuite
-    with ErsTestHelper {
+      with Matchers
+      with OptionValues
+      with MockitoSugar
+      with GuiceOneAppPerSuite
+      with ErsTestHelper
+      with LogCapturing
+      with ScalaFutures {
+
+  val retryTestLogger: Logger = Logger(classOf[RetryTest])
 
   class RetryTest extends Retryable {
     import scala.concurrent.duration._
+
+    override val logger: Logger = retryTestLogger
     val mockAppConfig: ApplicationConfig = mock[ApplicationConfig]
     when(mockAppConfig.retryDelay).thenReturn(1.millisecond)
 
@@ -52,47 +64,82 @@ class RetryableSpec
     val retryMock: RetryTestUtil = mock[RetryTestUtil]
   }
 
-  "withRetry" should {
-    "return the future data once the predicate has been fulfilled" in new RetryTest {
-      when(retryMock.f).thenReturn(Future.successful(true))
-      val result: Boolean = await(retryMock.f.withRetry(5)(b => b), 1, SECONDS)
-      result shouldBe true
-      verify(retryMock, times(1)).f
-    }
-
-    "retry if the predicate is not fulfilled" in new RetryTest {
-      when(retryMock.f).thenReturn(
-        Future.successful(false),
-        Future.successful(false),
-        Future.successful(true)
-      )
-      val result: Boolean = await(retryMock.f.withRetry(5)(b => b), 1, SECONDS)
-      result shouldBe true
-      verify(retryMock, times(3)).f
-    }
-
-    "retry up to a specified maximum number of times if the predicate is not fulfilled" in new RetryTest {
-      when(retryMock.f).thenReturn(
-        Future.successful(false),
-        Future.successful(false),
-        Future.successful(false),
-        Future.successful(false),
-        Future.successful(true)
-      )
-      intercept[Throwable](await(retryMock.f.withRetry(3)(b => b), 1, SECONDS))
-      verify(retryMock, times(3)).f
-    }
-
-    "return a LoopException if the predicate is never fulfilled" in new RetryTest {
-      when(retryMock.f).thenReturn(Future.successful(false))
-      val exception: LoopException[Boolean] = intercept[LoopException[Boolean]] {
-        await(retryMock.f.withRetry(1)(b => b), 1, SECONDS)
-      }
-      exception.finalFutureData shouldBe Some(false)
-      exception.retryNumber     shouldBe 1
-      exception.getMessage      shouldBe s"Failed to meet predicate after retrying ${exception.retryNumber} times."
-      verify(retryMock, times(1)).f
+  def generateExpectedRetryLogMessages(numberRetryLogs: Int,
+                                       appendMaxNumberRetiresMessage: Boolean = false,
+                                       schemeRef: String = "NOT DEFINED"): Seq[String] = {
+    val retryLogMessages: Seq[String] = (0 until numberRetryLogs).map((retry: Int) =>
+      s"[RetryableSpec][withRetry] Retrying call x$retry, schemeRef: $schemeRef"
+    )
+    if (appendMaxNumberRetiresMessage) {
+      retryLogMessages :+ s"[RetryableSpec][withRetry] EXHAUSTED MAX NUMBER OF RETRIES (${numberRetryLogs - 1} times)," +
+        s" schemeRef: $schemeRef"
+    } else {
+      retryLogMessages
     }
   }
 
+    "withRetry" should {
+
+      "return the future data once the predicate has been fulfilled" in new RetryTest {
+        when(retryMock.f).thenReturn(Future.successful(true))
+        val expectedLogMessage = "[RetryableSpec][withRetry] Retrying call x0, schemeRef: NOT DEFINED"
+        withCaptureOfLoggingFrom(retryTestLogger) { captureEvents =>
+          val result: Boolean = retryMock.f.withRetry(5, callingFunc = "RetryableSpec")(b => b).futureValue
+          assert(result)
+          assert(captureEvents.exists(_.getMessage.contains(expectedLogMessage)))
+        }
+
+        verify(retryMock, times(1)).f
+      }
+
+      "retry if the predicate is not fulfilled" in new RetryTest {
+        when(retryMock.f).thenReturn(
+          Future.successful(false),
+          Future.successful(false),
+          Future.successful(true)
+        )
+
+        withCaptureOfLoggingFrom(retryTestLogger) { captureEvents =>
+          val result: Boolean = retryMock.f.withRetry(5, callingFunc = "RetryableSpec")(b => b).futureValue
+          assert(result)
+          assert(captureEvents.map(_.getMessage) == generateExpectedRetryLogMessages(3))
+        }
+
+        verify(retryMock, times(3)).f
+      }
+
+      "retry up to a specified maximum number of times if the predicate is not fulfilled" in new RetryTest {
+        val schemeInfo: SchemeInfo = SchemeInfo("XA1100000000000", Instant.now, "1", "2016", "EMI", "EMI")
+        when(retryMock.f).thenReturn(
+          Future.successful(false),
+          Future.successful(false),
+          Future.successful(false),
+          Future.successful(false),
+          Future.successful(true)
+        )
+
+        withCaptureOfLoggingFrom(retryTestLogger) { captureEvents =>
+          val error: LoopException[Boolean] = intercept[LoopException[Boolean]] {
+            await(retryMock.f.withRetry(3, maybeSchemeInfo = Some(schemeInfo), callingFunc = "RetryableSpec")(b => b), 1, SECONDS)
+//            retryMock.f.withRetry(3, maybeSchemeInfo = Some(schemeInfo), callingFunc = "RetryableSpec")(b => b).futureValue
+          }
+          assert(error == LoopException(3, Some(false)))
+          assert(error.getMessage == "Failed to meet predicate after retrying 3 times.")
+          assert(captureEvents.map(_.getMessage) == generateExpectedRetryLogMessages(4, schemeRef = "XA1100000000000", appendMaxNumberRetiresMessage = true))
+        }
+
+        verify(retryMock, times(3)).f
+      }
+
+      "return a LoopException if the predicate is never fulfilled" in new RetryTest {
+        when(retryMock.f).thenReturn(Future.successful(false))
+        val exception: LoopException[Boolean] = intercept[LoopException[Boolean]] {
+          await(retryMock.f.withRetry(1, callingFunc = "RetryableSpec")(b => b), 1, SECONDS)
+        }
+        exception.finalFutureData shouldBe Some(false)
+        exception.retryNumber     shouldBe 1
+        exception.getMessage      shouldBe s"Failed to meet predicate after retrying ${exception.retryNumber} times."
+        verify(retryMock, times(1)).f
+      }
+    }
 }

--- a/test/utils/RetryableSpec.scala
+++ b/test/utils/RetryableSpec.scala
@@ -37,20 +37,20 @@ import scala.concurrent.duration.SECONDS
 
 class RetryableSpec
     extends AnyWordSpecLike
-      with Matchers
-      with OptionValues
-      with MockitoSugar
-      with GuiceOneAppPerSuite
-      with ErsTestHelper
-      with LogCapturing
-      with ScalaFutures {
+    with Matchers
+    with OptionValues
+    with MockitoSugar
+    with GuiceOneAppPerSuite
+    with ErsTestHelper
+    with LogCapturing
+    with ScalaFutures {
 
   val retryTestLogger: Logger = Logger(classOf[RetryTest])
 
   class RetryTest extends Retryable {
     import scala.concurrent.duration._
 
-    override val logger: Logger = retryTestLogger
+    override val logger: Logger          = retryTestLogger
     val mockAppConfig: ApplicationConfig = mock[ApplicationConfig]
     when(mockAppConfig.retryDelay).thenReturn(1.millisecond)
 
@@ -64,9 +64,11 @@ class RetryableSpec
     val retryMock: RetryTestUtil = mock[RetryTestUtil]
   }
 
-  def generateExpectedRetryLogMessages(numberRetryLogs: Int,
-                                       appendMaxNumberRetiresMessage: Boolean = false,
-                                       schemeRef: String = "NOT DEFINED"): Seq[String] = {
+  def generateExpectedRetryLogMessages(
+    numberRetryLogs: Int,
+    appendMaxNumberRetiresMessage: Boolean = false,
+    schemeRef: String = "NOT DEFINED"
+  ): Seq[String] = {
     val retryLogMessages: Seq[String] = (0 until numberRetryLogs).map((retry: Int) =>
       s"[RetryableSpec][withRetry] Retrying call x$retry, schemeRef: $schemeRef"
     )
@@ -78,67 +80,78 @@ class RetryableSpec
     }
   }
 
-    "withRetry" should {
+  "withRetry" should {
 
-      "return the future data once the predicate has been fulfilled" in new RetryTest {
-        when(retryMock.f).thenReturn(Future.successful(true))
-        val expectedLogMessage = "[RetryableSpec][withRetry] Retrying call x0, schemeRef: NOT DEFINED"
-        withCaptureOfLoggingFrom(retryTestLogger) { captureEvents =>
-          val result: Boolean = retryMock.f.withRetry(5, callingFunc = "RetryableSpec")(b => b).futureValue
-          assert(result)
-          assert(captureEvents.exists(_.getMessage.contains(expectedLogMessage)))
-        }
-
-        verify(retryMock, times(1)).f
+    "return the future data once the predicate has been fulfilled" in new RetryTest {
+      when(retryMock.f).thenReturn(Future.successful(true))
+      val expectedLogMessage = "[RetryableSpec][withRetry] Retrying call x0, schemeRef: NOT DEFINED"
+      withCaptureOfLoggingFrom(retryTestLogger) { captureEvents =>
+        val result: Boolean = retryMock.f.withRetry(5, callingFunc = "RetryableSpec")(b => b).futureValue
+        assert(result)
+        assert(captureEvents.exists(_.getMessage.contains(expectedLogMessage)))
       }
 
-      "retry if the predicate is not fulfilled" in new RetryTest {
-        when(retryMock.f).thenReturn(
-          Future.successful(false),
-          Future.successful(false),
-          Future.successful(true)
-        )
-
-        withCaptureOfLoggingFrom(retryTestLogger) { captureEvents =>
-          val result: Boolean = retryMock.f.withRetry(5, callingFunc = "RetryableSpec")(b => b).futureValue
-          assert(result)
-          assert(captureEvents.map(_.getMessage) == generateExpectedRetryLogMessages(3))
-        }
-
-        verify(retryMock, times(3)).f
-      }
-
-      "retry up to a specified maximum number of times if the predicate is not fulfilled" in new RetryTest {
-        val schemeInfo: SchemeInfo = SchemeInfo("XA1100000000000", Instant.now, "1", "2016", "EMI", "EMI")
-        when(retryMock.f).thenReturn(
-          Future.successful(false),
-          Future.successful(false),
-          Future.successful(false),
-          Future.successful(false),
-          Future.successful(true)
-        )
-
-        withCaptureOfLoggingFrom(retryTestLogger) { captureEvents =>
-          val error: LoopException[Boolean] = intercept[LoopException[Boolean]] {
-            await(retryMock.f.withRetry(3, maybeSchemeInfo = Some(schemeInfo), callingFunc = "RetryableSpec")(b => b), 1, SECONDS)
-          }
-          assert(error == LoopException(3, Some(false)))
-          assert(error.getMessage == "Failed to meet predicate after retrying 3 times.")
-          assert(captureEvents.map(_.getMessage) == generateExpectedRetryLogMessages(4, schemeRef = "XA1100000000000", appendMaxNumberRetiresMessage = true))
-        }
-
-        verify(retryMock, times(3)).f
-      }
-
-      "return a LoopException if the predicate is never fulfilled" in new RetryTest {
-        when(retryMock.f).thenReturn(Future.successful(false))
-        val exception: LoopException[Boolean] = intercept[LoopException[Boolean]] {
-          await(retryMock.f.withRetry(1, callingFunc = "RetryableSpec")(b => b), 1, SECONDS)
-        }
-        exception.finalFutureData shouldBe Some(false)
-        exception.retryNumber     shouldBe 1
-        exception.getMessage      shouldBe s"Failed to meet predicate after retrying ${exception.retryNumber} times."
-        verify(retryMock, times(1)).f
-      }
+      verify(retryMock, times(1)).f
     }
+
+    "retry if the predicate is not fulfilled" in new RetryTest {
+      when(retryMock.f).thenReturn(
+        Future.successful(false),
+        Future.successful(false),
+        Future.successful(true)
+      )
+
+      withCaptureOfLoggingFrom(retryTestLogger) { captureEvents =>
+        val result: Boolean = retryMock.f.withRetry(5, callingFunc = "RetryableSpec")(b => b).futureValue
+        assert(result)
+        assert(captureEvents.map(_.getMessage) == generateExpectedRetryLogMessages(3))
+      }
+
+      verify(retryMock, times(3)).f
+    }
+
+    "retry up to a specified maximum number of times if the predicate is not fulfilled" in new RetryTest {
+      val schemeInfo: SchemeInfo = SchemeInfo("XA1100000000000", Instant.now, "1", "2016", "EMI", "EMI")
+      when(retryMock.f).thenReturn(
+        Future.successful(false),
+        Future.successful(false),
+        Future.successful(false),
+        Future.successful(false),
+        Future.successful(true)
+      )
+
+      withCaptureOfLoggingFrom(retryTestLogger) { captureEvents =>
+        val error: LoopException[Boolean] = intercept[LoopException[Boolean]] {
+          await(
+            retryMock.f.withRetry(3, maybeSchemeInfo = Some(schemeInfo), callingFunc = "RetryableSpec")(b => b),
+            1,
+            SECONDS
+          )
+        }
+        assert(error == LoopException(3, Some(false)))
+        assert(error.getMessage == "Failed to meet predicate after retrying 3 times.")
+        assert(
+          captureEvents.map(_.getMessage) == generateExpectedRetryLogMessages(
+            4,
+            schemeRef = "XA1100000000000",
+            appendMaxNumberRetiresMessage = true
+          )
+        )
+      }
+
+      verify(retryMock, times(3)).f
+    }
+
+    "return a LoopException if the predicate is never fulfilled" in new RetryTest {
+      when(retryMock.f).thenReturn(Future.successful(false))
+      val exception: LoopException[Boolean] = intercept[LoopException[Boolean]] {
+        await(retryMock.f.withRetry(1, callingFunc = "RetryableSpec")(b => b), 1, SECONDS)
+      }
+      exception.finalFutureData shouldBe Some(false)
+      exception.retryNumber     shouldBe 1
+      exception.getMessage      shouldBe s"Failed to meet predicate after retrying ${exception.retryNumber} times."
+      verify(retryMock, times(1)).f
+    }
+  }
+
 }

--- a/test/utils/RetryableSpec.scala
+++ b/test/utils/RetryableSpec.scala
@@ -17,7 +17,6 @@
 package utils
 
 import config.ApplicationConfig
-import controllers.CsvFileUploadController
 import models.SchemeInfo
 import org.apache.pekko.actor.ActorSystem
 import org.mockito.Mockito.{times, verify, when}
@@ -67,14 +66,14 @@ class RetryableSpec
   def generateExpectedRetryLogMessages(
     numberRetryLogs: Int,
     appendMaxNumberRetiresMessage: Boolean = false,
-    schemeRef: String = "NOT DEFINED"
+    schemeRef: String = "<<NOT DEFINED>>"
   ): Seq[String] = {
     val retryLogMessages: Seq[String] = (0 until numberRetryLogs).map((retry: Int) =>
-      s"[RetryableSpec][withRetry] Retrying call x$retry, schemeRef: $schemeRef"
+      s"[Retryable][withRetry] - [RetryableSpec] call x$retry, schemeRef: $schemeRef"
     )
     if (appendMaxNumberRetiresMessage) {
-      retryLogMessages :+ s"[RetryableSpec][withRetry] EXHAUSTED MAX NUMBER OF RETRIES (${numberRetryLogs - 1} times)," +
-        s" schemeRef: $schemeRef"
+      retryLogMessages :+ s"[Retryable][withRetry] - [RetryableSpec] EXHAUSTED_MAX_NUMBER_OF_RETRIES " +
+        s"(${numberRetryLogs - 1} times), schemeRef: $schemeRef"
     } else {
       retryLogMessages
     }
@@ -84,7 +83,7 @@ class RetryableSpec
 
     "return the future data once the predicate has been fulfilled" in new RetryTest {
       when(retryMock.f).thenReturn(Future.successful(true))
-      val expectedLogMessage = "[RetryableSpec][withRetry] Retrying call x0, schemeRef: NOT DEFINED"
+      val expectedLogMessage = "[Retryable][withRetry] - [RetryableSpec] call x0, schemeRef: <<NOT DEFINED>>"
       withCaptureOfLoggingFrom(retryTestLogger) { captureEvents =>
         val result: Boolean = retryMock.f.withRetry(5, callingFunc = "RetryableSpec")(b => b).futureValue
         assert(result)
@@ -104,7 +103,7 @@ class RetryableSpec
       withCaptureOfLoggingFrom(retryTestLogger) { captureEvents =>
         val result: Boolean = retryMock.f.withRetry(5, callingFunc = "RetryableSpec")(b => b).futureValue
         assert(result)
-        assert(captureEvents.map(_.getMessage) == generateExpectedRetryLogMessages(3))
+        captureEvents.map(_.getMessage) should contain theSameElementsAs generateExpectedRetryLogMessages(3)
       }
 
       verify(retryMock, times(3)).f
@@ -128,15 +127,11 @@ class RetryableSpec
             SECONDS
           )
         }
-        assert(error == LoopException(3, Some(false)))
-        assert(error.getMessage == "Failed to meet predicate after retrying 3 times.")
-        assert(
-          captureEvents.map(_.getMessage) == generateExpectedRetryLogMessages(
-            4,
-            schemeRef = "XA1100000000000",
-            appendMaxNumberRetiresMessage = true
-          )
-        )
+        error            shouldBe LoopException(3, Some(false))
+        error.getMessage shouldBe "Failed to meet predicate after retrying 3 times."
+        val expectedRetryLogMessages =
+          generateExpectedRetryLogMessages(4, schemeRef = "XA1100000000000", appendMaxNumberRetiresMessage = true)
+        captureEvents.map(_.getMessage) should contain theSameElementsAs expectedRetryLogMessages
       }
 
       verify(retryMock, times(3)).f


### PR DESCRIPTION
Improve retry logging with the following:
- add scheme ref (when possible, is scheme ref not defined a default value is used) to improve ability to trace submissions through logs
- add log which includes "EXHAUSTED MAX NUMBER OF RETRIES", when this log is produced will produce log (see [here](https://github.com/hmrc/alert-config/pull/5557))
- add tests for updated logging

Example of logs:
```scala annotate
...
[[Retryable][withRetry] - [extractCsvCallbackData] call x9, schemeRef: XA1100000000000]
[[Retryable][withRetry] - [extractCsvCallbackData] call x10, schemeRef: XA1100000000000]
[[Retryable][withRetry] - [extractCsvCallbackData] EXHAUSTED_MAX_NUMBER_OF_RETRIES (10 times), schemeRef: XA1100000000000]
```