### PR TITLE
DDCE-8931: Add rate limit to prevent duplicate submissions 

### DIFF
--- a/app/config/ApplicationConfig.scala
+++ b/app/config/ApplicationConfig.scala
@@ -79,4 +79,7 @@ class ApplicationConfig @Inject() (config: ServicesConfig) {
   lazy val uploadFileSizeLimit: Int   = config.getInt("file-size.uploadSizeLimit")
   lazy val uploadFileSizeInMB: Double = uploadFileSizeLimit / 1000 / 1000.toDouble
 
+  val confirmationPageRateLimitTTLDuration: FiniteDuration =
+    FiniteDuration(config.getInt("confirmation-page-get.maxTps"), "s")
+
 }

--- a/app/controllers/ConfirmationPageController.scala
+++ b/app/controllers/ConfirmationPageController.scala
@@ -37,6 +37,7 @@ import java.time.format.DateTimeFormatter
 import java.util.concurrent.TimeUnit
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
+import scala.util.Try
 
 @Singleton
 class ConfirmationPageController @Inject() (
@@ -44,13 +45,20 @@ class ConfirmationPageController @Inject() (
   val ersConnector: ErsConnector,
   val auditEvents: AuditEvents,
   val sessionService: FrontendSessionService,
+  val rateLimiterCache: RateLimiterCache,
   globalErrorView: views.html.global_error,
   confirmationView: views.html.confirmation,
   authAction: AuthAction
 )(implicit val ec: ExecutionContext, val ersUtil: ERSUtil, val appConfig: ApplicationConfig)
     extends FrontendController(mcc) with I18nSupport with Metrics with JsonParser with Logging with Throttle {
 
-  val rateLimiterCache: RateLimiterCache = new RateLimiterCache(appConfig.confirmationPageRateLimitTTLDuration)
+  def generateRateLimitId(metadata: ErsMetaData): String = {
+    val MISSING_ID: String = "<<<MISSING>>>"
+    val schemeRef          = Try(metadata.schemeInfo.schemeRef).toOption.getOrElse(MISSING_ID)
+    val taxYear            = Try(metadata.schemeInfo.taxYear).toOption.getOrElse(MISSING_ID)
+    val empRef             = Try(metadata.empRef).toOption.getOrElse(MISSING_ID)
+    s"$schemeRef-$taxYear-$empRef"
+  }
 
   def confirmationPage() = authAction.async { implicit request =>
     {
@@ -61,8 +69,7 @@ class ConfirmationPageController @Inject() (
             s"[ConfirmationPageController][confirmationPage] Fetched request object with SAP Number: ${metadata.sapNumber} " +
               s"and schemeRef: ${metadata.schemeInfo.schemeRef}"
           )
-        rateLimitId: String    = s"${metadata.schemeInfo.schemeRef}-${metadata.schemeInfo.taxYear}-${metadata.empRef}"
-        output                <- withThrottle(rateLimitId, showConfirmationPage()(request, hc))
+        output                <- withThrottle(generateRateLimitId(metadata), showConfirmationPage()(request, hc))
       } yield output
     }.recoverWith { case RateLimitedException =>
       logger.info("[ConfirmationPageController][confirmationPage] Encountered RateLimitedException")

--- a/app/controllers/ConfirmationPageController.scala
+++ b/app/controllers/ConfirmationPageController.scala
@@ -24,6 +24,7 @@ import metrics.Metrics
 import play.api.Logging
 import play.api.i18n.{I18nSupport, Messages}
 import play.api.mvc._
+import repositories.RateLimiterCache
 import services.FrontendSessionService
 import services.audit.AuditEvents
 import uk.gov.hmrc.http.HeaderCarrier
@@ -31,7 +32,7 @@ import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import utils.SessionKeys.{BUNDLE_REF, DATE_TIME_SUBMITTED}
 import utils._
 
-import java.time.ZoneId
+import java.time.{Instant, ZoneId}
 import java.time.format.DateTimeFormatter
 import java.util.concurrent.TimeUnit
 import javax.inject.{Inject, Singleton}
@@ -47,16 +48,26 @@ class ConfirmationPageController @Inject() (
   confirmationView: views.html.confirmation,
   authAction: AuthAction
 )(implicit val ec: ExecutionContext, val ersUtil: ERSUtil, val appConfig: ApplicationConfig)
-    extends FrontendController(mcc) with I18nSupport with Metrics with JsonParser with Logging {
+    extends FrontendController(mcc) with I18nSupport with Metrics with JsonParser with Logging with Throttle {
 
-  def confirmationPage(): Action[AnyContent] = authAction.async { implicit request =>
-    sessionService.fetch[ErsMetaData](ersUtil.ERS_METADATA).map { ele =>
-      logger.info(
-        s"[ConfirmationPageController][confirmationPage] Fetched request object with SAP Number: ${ele.sapNumber} " +
-          s"and schemeRef: ${ele.schemeInfo.schemeRef}"
-      )
+  val rateLimiterCache: RateLimiterCache = new RateLimiterCache(appConfig.confirmationPageRateLimitTTLDuration)
+
+  def confirmationPage() = authAction.async { implicit request =>
+    {
+      for {
+        metadata: ErsMetaData <- sessionService.fetch[ErsMetaData](ersUtil.ERS_METADATA)
+        _                      =
+          logger.info(
+            s"[ConfirmationPageController][confirmationPage] Fetched request object with SAP Number: ${metadata.sapNumber} " +
+              s"and schemeRef: ${metadata.schemeInfo.schemeRef}"
+          )
+        rateLimitId: String    = s"${metadata.schemeInfo.schemeRef}-${metadata.schemeInfo.taxYear}-${metadata.empRef}"
+        output                <- withThrottle(rateLimitId, showConfirmationPage()(request, hc))
+      } yield output
+    }.recoverWith { case RateLimitedException =>
+      logger.info("[ConfirmationPageController][confirmationPage] Encountered RateLimitedException")
+      Future.successful(getGlobalErrorPage)
     }
-    showConfirmationPage()(request, hc)
   }
 
   def showConfirmationPage()(implicit

--- a/app/repositories/RateLimiterCache.scala
+++ b/app/repositories/RateLimiterCache.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package repositories
+
+import com.github.blemale.scaffeine.{Cache, Scaffeine}
+
+import java.time.Instant
+import javax.inject.Singleton
+import scala.concurrent.duration.FiniteDuration
+
+@Singleton
+class RateLimiterCache(val maxTpsForConfirmationPageGet: FiniteDuration) {
+
+  protected val cache: Cache[String, Instant] = Scaffeine()
+    .expireAfterWrite(maxTpsForConfirmationPageGet)
+    .build[String, Instant]()
+
+  def insertRateLimiter(rateLimitId: String, createAt: Instant): Unit =
+    cache.put(rateLimitId, createAt)
+
+  def getRateLimiter(rateLimitId: String): Option[Instant] =
+    cache.getIfPresent(rateLimitId)
+
+}

--- a/app/repositories/RateLimiterCache.scala
+++ b/app/repositories/RateLimiterCache.scala
@@ -32,7 +32,7 @@ class RateLimiterCache @Inject() (appConfig: ApplicationConfig) {
     .expireAfterWrite(maxTpsForConfirmationPageGet)
     .build[String, Instant]()
 
-  def rateLimitPresentInCache(rateLimitId: String, createAt: Instant): Boolean =
+  def isRateLimitPresentInCache(rateLimitId: String, createAt: Instant): Boolean =
     cache.underlying.asMap().putIfAbsent(rateLimitId, createAt) != null
 
 }

--- a/app/repositories/RateLimiterCache.scala
+++ b/app/repositories/RateLimiterCache.scala
@@ -17,22 +17,22 @@
 package repositories
 
 import com.github.blemale.scaffeine.{Cache, Scaffeine}
+import config.ApplicationConfig
 
 import java.time.Instant
-import javax.inject.Singleton
+import javax.inject.{Inject, Singleton}
 import scala.concurrent.duration.FiniteDuration
 
 @Singleton
-class RateLimiterCache(val maxTpsForConfirmationPageGet: FiniteDuration) {
+class RateLimiterCache @Inject() (appConfig: ApplicationConfig) {
+
+  val maxTpsForConfirmationPageGet: FiniteDuration = appConfig.confirmationPageRateLimitTTLDuration
 
   protected val cache: Cache[String, Instant] = Scaffeine()
     .expireAfterWrite(maxTpsForConfirmationPageGet)
     .build[String, Instant]()
 
-  def insertRateLimiter(rateLimitId: String, createAt: Instant): Unit =
-    cache.put(rateLimitId, createAt)
-
-  def getRateLimiter(rateLimitId: String): Option[Instant] =
-    cache.getIfPresent(rateLimitId)
+  def rateLimitPresentInCache(rateLimitId: String, createAt: Instant): Boolean =
+    cache.underlying.asMap().putIfAbsent(rateLimitId, createAt) != null
 
 }

--- a/app/utils/RateLimiter.scala
+++ b/app/utils/RateLimiter.scala
@@ -31,7 +31,7 @@ trait Throttle extends Logging {
     rateLimitId: String,
     block: => Future[A]
   ): Future[A] =
-    if (rateLimiterCache.rateLimitPresentInCache(rateLimitId, Instant.now())) {
+    if (rateLimiterCache.isRateLimitPresentInCache(rateLimitId, Instant.now())) {
       logger.error(
         s"[Throttle][withThrottle] Request failed to acquire a permit at a tps of ${rateLimiterCache.maxTpsForConfirmationPageGet}"
       )

--- a/app/utils/RateLimiter.scala
+++ b/app/utils/RateLimiter.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import play.api.Logging
+import repositories.RateLimiterCache
+
+import java.time.Instant
+import scala.concurrent.Future
+
+case object RateLimitedException extends RuntimeException
+
+trait Throttle extends Logging {
+  def rateLimiterCache: RateLimiterCache
+
+  def withThrottle[A](
+    rateLimitId: String,
+    block: => Future[A]
+  ): Future[A] =
+    if (rateLimiterCache.getRateLimiter(rateLimitId).isEmpty) {
+      rateLimiterCache.insertRateLimiter(rateLimitId, Instant.now())
+      block
+    } else {
+      logger.error(
+        s"[Throttle][withThrottle] Request failed to acquire a permit at a tps of ${rateLimiterCache.maxTpsForConfirmationPageGet}"
+      )
+      Future.failed(RateLimitedException)
+    }
+
+}

--- a/app/utils/RateLimiter.scala
+++ b/app/utils/RateLimiter.scala
@@ -31,14 +31,13 @@ trait Throttle extends Logging {
     rateLimitId: String,
     block: => Future[A]
   ): Future[A] =
-    if (rateLimiterCache.getRateLimiter(rateLimitId).isEmpty) {
-      rateLimiterCache.insertRateLimiter(rateLimitId, Instant.now())
-      block
-    } else {
+    if (rateLimiterCache.rateLimitPresentInCache(rateLimitId, Instant.now())) {
       logger.error(
         s"[Throttle][withThrottle] Request failed to acquire a permit at a tps of ${rateLimiterCache.maxTpsForConfirmationPageGet}"
       )
       Future.failed(RateLimitedException)
+    } else {
+      block
     }
 
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -173,3 +173,5 @@ mongodb {
 file-size {
   uploadSizeLimit = 100000 // 100KB for over file size limit error page acceptance tests
 }
+
+confirmation-page-get.maxTps = 1.0

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -4,7 +4,7 @@ object AppDependencies {
 
   private val openHtmlVersion  = "1.1.34"
   private val bootstrapVersion = "10.7.0"
-  private val mongoVersion     = "2.12.0"
+  private val mongoVersion     = "2.13.0"
 
   private val compile: Seq[ModuleID] = Seq(
     "uk.gov.hmrc"            %% "bootstrap-frontend-play-30" % bootstrapVersion,
@@ -14,7 +14,8 @@ object AppDependencies {
     "io.github.openhtmltopdf" % "openhtmltopdf-pdfbox"       % openHtmlVersion,
     "commons-codec"           % "commons-codec"              % "1.21.0",
     "commons-io"              % "commons-io"                 % "2.21.0",
-    "io.github.openhtmltopdf" % "openhtmltopdf-svg-support"  % openHtmlVersion
+    "io.github.openhtmltopdf" % "openhtmltopdf-svg-support"  % openHtmlVersion,
+    "com.github.blemale"     %% "scaffeine"                  % "5.3.0"
   )
 
   private val test: Seq[ModuleID] = Seq(

--- a/test/controllers/ConfirmationPageControllerSpec.scala
+++ b/test/controllers/ConfirmationPageControllerSpec.scala
@@ -20,35 +20,39 @@ import controllers.auth.RequestWithOptionalAuthContext
 import models._
 import org.apache.pekko.stream.Materializer
 import org.jsoup.Jsoup
-import org.mockito.ArgumentMatchers._
+import org.mockito.ArgumentMatchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 import org.scalatest.{BeforeAndAfterEach, OptionValues}
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.http.Status
-import play.api.i18n
+import play.api.{Logger, i18n}
 import play.api.i18n.{MessagesApi, MessagesImpl}
 import play.api.libs.json.JsValue
 import play.api.mvc._
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
+import uk.gov.hmrc.play.bootstrap.tools.LogCapturing
 import utils.Fixtures.ersRequestObject
 import utils._
 import views.html.{confirmation, global_error}
 
 import java.time.Instant
+import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{ExecutionContext, Future}
 
 class ConfirmationPageControllerSpec
     extends AnyWordSpecLike
     with Matchers
     with OptionValues
-    with ERSFakeApplicationConfig
     with ErsTestHelper
     with BeforeAndAfterEach
-    with GuiceOneAppPerSuite {
+    with GuiceOneAppPerSuite
+    with LogCapturing {
+
+  val confirmationPageControllerLogger: Logger = Logger(classOf[ConfirmationPageController])
 
   val mockMCC: MessagesControllerComponents = DefaultMessagesControllerComponents(
     messagesActionBuilder,
@@ -84,13 +88,15 @@ class ConfirmationPageControllerSpec
     val ersSummaryNilReturn2 =
       ErsSummary("testbundle", "2", None, Instant.now, rsc, None, None, None, None, None, None, None, None)
 
+    when(mockAppConfig.confirmationPageRateLimitTTLDuration).thenReturn(FiniteDuration(1, "s"))
+
     def buildFakeConfirmationPageController(
       isNilReturn: Boolean = false,
       bundleRes: Future[String] = Future.successful("Bundle12345"),
-      allDataRes: Future[ErsSummary] = Future.successful(ersSummary),
       ersMetaRes: Future[ErsMetaData] = Future.successful(rsc),
       presubmission: Future[HttpResponse] = Future.successful(HttpResponse(OK, "")),
-      requestObjectRes: Future[RequestObject] = Future.successful(ersRequestObject)
+      requestObjectRes: Future[RequestObject] = Future.successful(ersRequestObject),
+      saveAndSubmitWait: Boolean = false
     ): ConfirmationPageController =
       new ConfirmationPageController(
         mockMCC,
@@ -101,6 +107,8 @@ class ConfirmationPageControllerSpec
         confirmationView,
         testAuthAction
       ) {
+
+        override val logger: Logger = confirmationPageControllerLogger
 
         when(
           mockErsConnector.connectToEtmpSummarySubmit(anyString(), any[JsValue]())(any(), any())
@@ -123,10 +131,18 @@ class ConfirmationPageControllerSpec
           mockSessionService.fetch[RequestObject](refEq("ErsRequestObject"))(any(), any())
         ) thenReturn requestObjectRes
 
+        when(mockErsConnector.saveMetadata(any())(any(), any())) thenReturn Future.successful(HttpResponse(OK))
+        when(mockErsConnector.submitReturnToBackend(any())(any(), any())) thenReturn Future.successful(HttpResponse(OK))
+
         override def saveAndSubmit(alldata: ErsSummary, all: ErsMetaData, bundle: String)(implicit
           request: RequestWithOptionalAuthContext[AnyContent],
           hc: HeaderCarrier
-        ): Future[Result] = Future(Ok)
+        ): Future[Result] = {
+          if (saveAndSubmitWait) {
+            Thread.sleep(2000L) // wait 2s
+          }
+          super.saveAndSubmit(alldata, all, bundle)
+        }
       }
 
     "give a redirect status (to company authentication frontend) if user is not authenticated" in {
@@ -270,6 +286,31 @@ class ConfirmationPageControllerSpec
       status(result)        shouldBe Status.OK
       contentAsString(result) should include(testMessages("ers_confirmation.submitted"))
     }
+
+    "log a RateLimitedException when multiple requests are made to confirmationPage within rate limit, return global " +
+      "error page for requests outside limit" in {
+        setAuthMocks()
+
+        val controllerUnderTest: ConfirmationPageController =
+          buildFakeConfirmationPageController(saveAndSubmitWait = true)
+
+        withCaptureOfLoggingFrom(confirmationPageControllerLogger) { captureEvents =>
+          val callOne: Future[Result] =
+            controllerUnderTest.confirmationPage().apply(Fixtures.buildFakeRequestWithSessionId("GET"))
+          val callTwo: Future[Result] =
+            controllerUnderTest.confirmationPage().apply(Fixtures.buildFakeRequestWithSessionId("GET"))
+
+          contentAsString(callOne) should include(testMessages("ers_confirmation.submitted"))
+          contentAsString(callTwo) should include(testMessages("ers.global_errors.message"))
+
+          val expectedRateLimitLogs: Seq[String] = Seq(
+            "[Throttle][withThrottle] Request failed to acquire a permit at a tps of 1 second",
+            "[ConfirmationPageController][confirmationPage] Encountered RateLimitedException"
+          )
+          captureEvents.map(_.getMessage) should contain allElementsOf expectedRateLimitLogs
+        }
+
+      }
 
   }
 

--- a/test/controllers/ConfirmationPageControllerSpec.scala
+++ b/test/controllers/ConfirmationPageControllerSpec.scala
@@ -33,6 +33,7 @@ import play.api.libs.json.JsValue
 import play.api.mvc._
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
+import repositories.RateLimiterCache
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.play.bootstrap.tools.LogCapturing
 import utils.Fixtures.ersRequestObject
@@ -77,6 +78,7 @@ class ConfirmationPageControllerSpec
     when(mockErsUtil.ERS_METADATA).thenReturn("ErsMetaData")
     when(mockErsUtil.OPTION_NIL_RETURN).thenReturn("2")
     when(mockErsUtil.VALIDATED_SHEETS).thenReturn("validated-sheets")
+    when(mockAppConfig.confirmationPageRateLimitTTLDuration).thenReturn(FiniteDuration(10, "s"))
   }
 
   "calling showConfirmationPage" should {
@@ -88,21 +90,19 @@ class ConfirmationPageControllerSpec
     val ersSummaryNilReturn2 =
       ErsSummary("testbundle", "2", None, Instant.now, rsc, None, None, None, None, None, None, None, None)
 
-    when(mockAppConfig.confirmationPageRateLimitTTLDuration).thenReturn(FiniteDuration(1, "s"))
-
     def buildFakeConfirmationPageController(
       isNilReturn: Boolean = false,
       bundleRes: Future[String] = Future.successful("Bundle12345"),
       ersMetaRes: Future[ErsMetaData] = Future.successful(rsc),
       presubmission: Future[HttpResponse] = Future.successful(HttpResponse(OK, "")),
-      requestObjectRes: Future[RequestObject] = Future.successful(ersRequestObject),
-      saveAndSubmitWait: Boolean = false
+      requestObjectRes: Future[RequestObject] = Future.successful(ersRequestObject)
     ): ConfirmationPageController =
       new ConfirmationPageController(
         mockMCC,
         mockErsConnector,
         mockAuditEvents,
         mockSessionService,
+        new RateLimiterCache(mockAppConfig),
         globalErrorView,
         confirmationView,
         testAuthAction
@@ -133,16 +133,6 @@ class ConfirmationPageControllerSpec
 
         when(mockErsConnector.saveMetadata(any())(any(), any())) thenReturn Future.successful(HttpResponse(OK))
         when(mockErsConnector.submitReturnToBackend(any())(any(), any())) thenReturn Future.successful(HttpResponse(OK))
-
-        override def saveAndSubmit(alldata: ErsSummary, all: ErsMetaData, bundle: String)(implicit
-          request: RequestWithOptionalAuthContext[AnyContent],
-          hc: HeaderCarrier
-        ): Future[Result] = {
-          if (saveAndSubmitWait) {
-            Thread.sleep(2000L) // wait 2s
-          }
-          super.saveAndSubmit(alldata, all, bundle)
-        }
       }
 
     "give a redirect status (to company authentication frontend) if user is not authenticated" in {
@@ -292,11 +282,13 @@ class ConfirmationPageControllerSpec
         setAuthMocks()
 
         val controllerUnderTest: ConfirmationPageController =
-          buildFakeConfirmationPageController(saveAndSubmitWait = true)
+          buildFakeConfirmationPageController()
 
         withCaptureOfLoggingFrom(confirmationPageControllerLogger) { captureEvents =>
           val callOne: Future[Result] =
             controllerUnderTest.confirmationPage().apply(Fixtures.buildFakeRequestWithSessionId("GET"))
+
+          Thread.sleep(1000L) // Wait for first request to insert record into cache
           val callTwo: Future[Result] =
             controllerUnderTest.confirmationPage().apply(Fixtures.buildFakeRequestWithSessionId("GET"))
 
@@ -304,7 +296,7 @@ class ConfirmationPageControllerSpec
           contentAsString(callTwo) should include(testMessages("ers.global_errors.message"))
 
           val expectedRateLimitLogs: Seq[String] = Seq(
-            "[Throttle][withThrottle] Request failed to acquire a permit at a tps of 1 second",
+            "[Throttle][withThrottle] Request failed to acquire a permit at a tps of 10 seconds",
             "[ConfirmationPageController][confirmationPage] Encountered RateLimitedException"
           )
           captureEvents.map(_.getMessage) should contain allElementsOf expectedRateLimitLogs
@@ -330,6 +322,7 @@ class ConfirmationPageControllerSpec
         mockErsConnector,
         mockAuditEvents,
         mockSessionService,
+        new RateLimiterCache(mockAppConfig),
         globalErrorView,
         confirmationView,
         testAuthAction

--- a/test/repository/RateLimiterCacheSpec.scala
+++ b/test/repository/RateLimiterCacheSpec.scala
@@ -39,12 +39,13 @@ class RateLimiterCacheSpec extends AnyWordSpecLike {
     "insert and retrieve a key value pair from cache" in new RateLimitCacheTest(
       new FiniteDuration(10, TimeUnit.SECONDS)
     ) {
-      rateLimiterCache.insertRateLimiter("123", Instant.now())
-      rateLimiterCache.insertRateLimiter("456", Instant.now())
-      rateLimiterCache.insertRateLimiter("789", Instant.now())
-      assert(rateLimiterCache.getRateLimiter("123").isDefined)
-      assert(rateLimiterCache.getRateLimiter("456").isDefined)
-      assert(rateLimiterCache.getRateLimiter("789").isDefined)
+      val createdAt: Instant = Instant.parse("2026-08-04T12:30:00Z")
+      rateLimiterCache.insertRateLimiter("123", createdAt)
+      rateLimiterCache.insertRateLimiter("456", createdAt)
+      rateLimiterCache.insertRateLimiter("789", createdAt)
+      rateLimiterCache.getRateLimiter("123") mustBe Some(createdAt)
+      rateLimiterCache.getRateLimiter("456") mustBe Some(createdAt)
+      rateLimiterCache.getRateLimiter("789") mustBe Some(createdAt)
     }
 
     "overwrite records which the same key" in new RateLimitCacheTest(new FiniteDuration(10, TimeUnit.SECONDS)) {

--- a/test/repository/RateLimiterCacheSpec.scala
+++ b/test/repository/RateLimiterCacheSpec.scala
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package repository
+
+import scala.concurrent.duration._
+
+import com.github.benmanes.caffeine.cache.Ticker
+import com.github.blemale.scaffeine.{Cache, Scaffeine}
+import org.scalatest.matchers.must.Matchers.convertToAnyMustWrapper
+import org.scalatest.wordspec.AnyWordSpecLike
+import repositories.RateLimiterCache
+
+import java.time.Instant
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicLong
+import scala.concurrent.duration.FiniteDuration
+
+class RateLimiterCacheSpec extends AnyWordSpecLike {
+
+  class RateLimitCacheTest(expiry: FiniteDuration) {
+    val rateLimiterCache: RateLimiterCache = new RateLimiterCache(expiry)
+  }
+
+  "RateLimiterCache" should {
+    "insert and retrieve a key value pair from cache" in new RateLimitCacheTest(
+      new FiniteDuration(10, TimeUnit.SECONDS)
+    ) {
+      rateLimiterCache.insertRateLimiter("123", Instant.now())
+      rateLimiterCache.insertRateLimiter("456", Instant.now())
+      rateLimiterCache.insertRateLimiter("789", Instant.now())
+      assert(rateLimiterCache.getRateLimiter("123").isDefined)
+      assert(rateLimiterCache.getRateLimiter("456").isDefined)
+      assert(rateLimiterCache.getRateLimiter("789").isDefined)
+    }
+
+    "overwrite records which the same key" in new RateLimitCacheTest(new FiniteDuration(10, TimeUnit.SECONDS)) {
+      rateLimiterCache.insertRateLimiter("123", Instant.parse("2026-08-04T12:30:00Z"))
+      rateLimiterCache.insertRateLimiter("123", Instant.parse("2026-08-04T12:31:00Z"))
+      rateLimiterCache.getRateLimiter("123") mustBe Some(Instant.parse("2026-08-04T12:31:00Z"))
+    }
+  }
+
+  "getRateLimiter" should {
+
+    "return None if there is no rate limit for a given id" in new RateLimitCacheTest(
+      new FiniteDuration(10, TimeUnit.SECONDS)
+    ) {
+      rateLimiterCache.getRateLimiter("123") mustBe None
+    }
+
+    "return None only when the rate limiter record has expired" in {
+
+      class CustomTicker extends Ticker {
+        private val time = new AtomicLong(0L)
+
+        def advance(nanos: Long): Unit = time.addAndGet(nanos)
+        override def read(): Long      = time.get()
+      }
+
+      val ticker: CustomTicker = new CustomTicker()
+
+      val rateLimiterCache: RateLimiterCache = new RateLimiterCache(new FiniteDuration(60L, TimeUnit.SECONDS)) {
+        override protected val cache: Cache[String, Instant] = Scaffeine()
+          .expireAfterWrite(new FiniteDuration(60L, TimeUnit.SECONDS))
+          .ticker(ticker)
+          .build[String, Instant]()
+      }
+
+      val createdAtTime: Instant = Instant.now()
+      rateLimiterCache.insertRateLimiter("123", createdAtTime)
+
+      ticker.advance(30.seconds.toNanos) // Advance 30s
+      rateLimiterCache.getRateLimiter("123") mustBe Some(createdAtTime)
+
+      ticker.advance(29.seconds.toNanos) // Advance 29s
+      rateLimiterCache.getRateLimiter("123") mustBe Some(createdAtTime)
+
+      ticker.advance(1.seconds.toNanos) // Advance 1s
+      rateLimiterCache.getRateLimiter("123") mustBe None
+    }
+  }
+
+}

--- a/test/repository/RateLimiterCacheSpec.scala
+++ b/test/repository/RateLimiterCacheSpec.scala
@@ -62,13 +62,13 @@ class RateLimiterCacheSpec extends AnyWordSpecLike {
     override def read(): Long      = time.get()
   }
 
-  "rateLimitPresentInCache" should {
+  "isRateLimitPresentInCache" should {
     "return false if a rate limit with a given id is not in the cache" in new RateLimitCacheTestSetup(
       new FiniteDuration(10, TimeUnit.SECONDS)
     ) {
-      rateLimiterCache.rateLimitPresentInCache("123", staticCreatedAt) mustBe false
-      rateLimiterCache.rateLimitPresentInCache("456", staticCreatedAt) mustBe false
-      rateLimiterCache.rateLimitPresentInCache("789", staticCreatedAt) mustBe false
+      rateLimiterCache.isRateLimitPresentInCache("123", staticCreatedAt) mustBe false
+      rateLimiterCache.isRateLimitPresentInCache("456", staticCreatedAt) mustBe false
+      rateLimiterCache.isRateLimitPresentInCache("789", staticCreatedAt) mustBe false
     }
 
     "return true if there is already a record with a given id" in new RateLimitCacheTestSetup(
@@ -77,7 +77,7 @@ class RateLimiterCacheSpec extends AnyWordSpecLike {
         ("123", staticCreatedAt)
       )
     ) {
-      rateLimiterCache.rateLimitPresentInCache("123", staticCreatedAt) mustBe true
+      rateLimiterCache.isRateLimitPresentInCache("123", staticCreatedAt) mustBe true
     }
 
     "return false only when the rate limiter record has expired" in new RateLimitCacheTestSetup(
@@ -88,13 +88,13 @@ class RateLimiterCacheSpec extends AnyWordSpecLike {
       )
     ) {
       customTicker.advance(30.seconds.toNanos) // Advance 30s
-      rateLimiterCache.rateLimitPresentInCache("123", staticCreatedAt) mustBe true
+      rateLimiterCache.isRateLimitPresentInCache("123", staticCreatedAt) mustBe true
 
       customTicker.advance(29.seconds.toNanos) // Advance 29s
-      rateLimiterCache.rateLimitPresentInCache("123", staticCreatedAt) mustBe true
+      rateLimiterCache.isRateLimitPresentInCache("123", staticCreatedAt) mustBe true
 
       customTicker.advance(1.seconds.toNanos) // Advance 1s
-      rateLimiterCache.rateLimitPresentInCache("123", staticCreatedAt) mustBe false
+      rateLimiterCache.isRateLimitPresentInCache("123", staticCreatedAt) mustBe false
     }
   }
 

--- a/test/repository/RateLimiterCacheSpec.scala
+++ b/test/repository/RateLimiterCacheSpec.scala
@@ -17,12 +17,15 @@
 package repository
 
 import scala.concurrent.duration._
-
 import com.github.benmanes.caffeine.cache.Ticker
+import com.github.benmanes.caffeine.cache.Ticker.systemTicker
 import com.github.blemale.scaffeine.{Cache, Scaffeine}
+import config.ApplicationConfig
+import org.mockito.Mockito.when
 import org.scalatest.matchers.must.Matchers.convertToAnyMustWrapper
 import org.scalatest.wordspec.AnyWordSpecLike
 import repositories.RateLimiterCache
+import utils.Fixtures.mock
 
 import java.time.Instant
 import java.util.concurrent.TimeUnit
@@ -31,67 +34,67 @@ import scala.concurrent.duration.FiniteDuration
 
 class RateLimiterCacheSpec extends AnyWordSpecLike {
 
-  class RateLimitCacheTest(expiry: FiniteDuration) {
-    val rateLimiterCache: RateLimiterCache = new RateLimiterCache(expiry)
+  val staticCreatedAt: Instant = Instant.parse("2026-08-04T12:30:00Z")
+
+  class RateLimitCacheTestSetup(
+    expiry: FiniteDuration,
+    ticker: Ticker = systemTicker,
+    initData: Map[String, Instant] = Map.empty[String, Instant]
+  ) {
+    val mockAppConfigWithExpiry: ApplicationConfig = mock[ApplicationConfig]
+    when(mockAppConfigWithExpiry.confirmationPageRateLimitTTLDuration).thenReturn(expiry)
+
+    val rateLimiterCache: RateLimiterCache = new RateLimiterCache(mockAppConfigWithExpiry) {
+      override protected val cache: Cache[String, Instant] = Scaffeine()
+        .expireAfterWrite(expiry)
+        .ticker(ticker)
+        .build[String, Instant]()
+
+      cache.putAll(initData)
+    }
+
   }
 
-  "RateLimiterCache" should {
-    "insert and retrieve a key value pair from cache" in new RateLimitCacheTest(
-      new FiniteDuration(10, TimeUnit.SECONDS)
-    ) {
-      val createdAt: Instant = Instant.parse("2026-08-04T12:30:00Z")
-      rateLimiterCache.insertRateLimiter("123", createdAt)
-      rateLimiterCache.insertRateLimiter("456", createdAt)
-      rateLimiterCache.insertRateLimiter("789", createdAt)
-      rateLimiterCache.getRateLimiter("123") mustBe Some(createdAt)
-      rateLimiterCache.getRateLimiter("456") mustBe Some(createdAt)
-      rateLimiterCache.getRateLimiter("789") mustBe Some(createdAt)
-    }
+  object customTicker extends Ticker {
+    private val time = new AtomicLong(0L)
 
-    "overwrite records which the same key" in new RateLimitCacheTest(new FiniteDuration(10, TimeUnit.SECONDS)) {
-      rateLimiterCache.insertRateLimiter("123", Instant.parse("2026-08-04T12:30:00Z"))
-      rateLimiterCache.insertRateLimiter("123", Instant.parse("2026-08-04T12:31:00Z"))
-      rateLimiterCache.getRateLimiter("123") mustBe Some(Instant.parse("2026-08-04T12:31:00Z"))
-    }
+    def advance(nanos: Long): Unit = time.addAndGet(nanos)
+    override def read(): Long      = time.get()
   }
 
-  "getRateLimiter" should {
-
-    "return None if there is no rate limit for a given id" in new RateLimitCacheTest(
+  "rateLimitPresentInCache" should {
+    "return false if a rate limit with a given id is not in the cache" in new RateLimitCacheTestSetup(
       new FiniteDuration(10, TimeUnit.SECONDS)
     ) {
-      rateLimiterCache.getRateLimiter("123") mustBe None
+      rateLimiterCache.rateLimitPresentInCache("123", staticCreatedAt) mustBe false
+      rateLimiterCache.rateLimitPresentInCache("456", staticCreatedAt) mustBe false
+      rateLimiterCache.rateLimitPresentInCache("789", staticCreatedAt) mustBe false
     }
 
-    "return None only when the rate limiter record has expired" in {
+    "return true if there is already a record with a given id" in new RateLimitCacheTestSetup(
+      new FiniteDuration(10, TimeUnit.SECONDS),
+      initData = Map(
+        ("123", staticCreatedAt)
+      )
+    ) {
+      rateLimiterCache.rateLimitPresentInCache("123", staticCreatedAt) mustBe true
+    }
 
-      class CustomTicker extends Ticker {
-        private val time = new AtomicLong(0L)
+    "return false only when the rate limiter record has expired" in new RateLimitCacheTestSetup(
+      new FiniteDuration(60L, TimeUnit.SECONDS),
+      customTicker,
+      initData = Map(
+        ("123", staticCreatedAt)
+      )
+    ) {
+      customTicker.advance(30.seconds.toNanos) // Advance 30s
+      rateLimiterCache.rateLimitPresentInCache("123", staticCreatedAt) mustBe true
 
-        def advance(nanos: Long): Unit = time.addAndGet(nanos)
-        override def read(): Long      = time.get()
-      }
+      customTicker.advance(29.seconds.toNanos) // Advance 29s
+      rateLimiterCache.rateLimitPresentInCache("123", staticCreatedAt) mustBe true
 
-      val ticker: CustomTicker = new CustomTicker()
-
-      val rateLimiterCache: RateLimiterCache = new RateLimiterCache(new FiniteDuration(60L, TimeUnit.SECONDS)) {
-        override protected val cache: Cache[String, Instant] = Scaffeine()
-          .expireAfterWrite(new FiniteDuration(60L, TimeUnit.SECONDS))
-          .ticker(ticker)
-          .build[String, Instant]()
-      }
-
-      val createdAtTime: Instant = Instant.now()
-      rateLimiterCache.insertRateLimiter("123", createdAtTime)
-
-      ticker.advance(30.seconds.toNanos) // Advance 30s
-      rateLimiterCache.getRateLimiter("123") mustBe Some(createdAtTime)
-
-      ticker.advance(29.seconds.toNanos) // Advance 29s
-      rateLimiterCache.getRateLimiter("123") mustBe Some(createdAtTime)
-
-      ticker.advance(1.seconds.toNanos) // Advance 1s
-      rateLimiterCache.getRateLimiter("123") mustBe None
+      customTicker.advance(1.seconds.toNanos) // Advance 1s
+      rateLimiterCache.rateLimitPresentInCache("123", staticCreatedAt) mustBe false
     }
   }
 


### PR DESCRIPTION
Overview:
- Add caffeine cache to prevent the same user clicking the submit button multiple times
- Tests for cache
- Mongo lib bump

Overview of caffeine cache logic flow:
- User hits submit button 
- A unique identifier for a user is created consisting of `schemeRef`, `taxYear`, `empRef`
- If there is no record with the user identifier present in the cache a record is inserted
- If there is already a record in the cache with the identifier the user is redirected to the global error page
- The records expire after 1s