### PR TITLE
DDCE-8930: Add prevent double click attribute

### DIFF
--- a/app/views/confirm_delete_company.scala.html
+++ b/app/views/confirm_delete_company.scala.html
@@ -96,10 +96,9 @@
         ))
 
         @govukButton(Button(
-            preventDoubleClick = Some(true),
             inputType = Some("submit"),
             content = Text(messages("ers.continue")),
-            attributes = Map("id" -> "continue"),
+            attributes = Map("id" -> "continue", "data-prevent-double-click" -> "true"),
         ))
     }
 }

--- a/app/views/summary.scala.html
+++ b/app/views/summary.scala.html
@@ -230,7 +230,7 @@
 
     @govukButton(Button(
         content = Text(messages("ers_summary_declaration.button")),
-        attributes = Map("id" -> "continue"),
+        attributes = Map("id" -> "continue", "data-prevent-double-click" -> "true"),
         href = Some(routes.ConfirmationPageController.confirmationPage().url)
     ))
 }


### PR DESCRIPTION
Overview:
- Added "data-prevent-double-click" -> "true" to summary view and confirmation delete subsidiary view
- I tried using preventDoubleClick directly but that didnt seem to be working